### PR TITLE
Fix EPUBPackage items and metadata initialization

### DIFF
--- a/cnxepub.py
+++ b/cnxepub.py
@@ -72,10 +72,10 @@ class EPUBPackage(MutableSequence):
     """EPUB3 package"""
     # TODO Navigation document requirement on output/input
 
-    def __init__(self, metadata={}, items=[], spine_order=None):
+    def __init__(self, metadata=None, items=None, spine_order=None):
         # TODO Metadata will become a mutable sequence object.
-        self.metadata = metadata
-        self._items = items
+        self.metadata = metadata or {}
+        self._items = items or []
         self._spine_indexes = spine_order  # TODO Ordered reference object, similar to nav.
 
     @classmethod

--- a/tests.py
+++ b/tests.py
@@ -72,6 +72,17 @@ class EPUBTestCase(unittest.TestCase):
                     if i.name == "e3d625fe893b3f1f9aaef3bdf6bfa15c.png"][0]
         self.assertIn(resource, package)
 
+    def test_parsing_same_file_twice(self):
+        from cnxepub import EPUB
+
+        epub1 = EPUB.from_file(SINGLE_OPF_FILEPATH)
+        epub2 = EPUB.from_file(SINGLE_OPF_FILEPATH)
+
+        self.assertEqual(len(epub1), 1)
+        self.assertEqual(len(epub1[0]), 9)
+        self.assertEqual(len(epub2), 1)
+        self.assertEqual(len(epub2[0]), 9)
+
 
 class HtmlMetadataParsingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
`metadata` and `items` were only initialized once, so we were using the same list and dict across the different EPUBPackages.
