### PR TITLE
Make cnx-epub python3 compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
 before_install:
   # Install the coverage utility and coveralls reporting utility
   - pip install coverage

--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -107,7 +107,7 @@ def _make_package(binder):
                                           is_translucent=binder.is_translucent)
     navigation_document_name = "{}.xhtml".format(package_id)
     item = Item(str(navigation_document_name),
-                io.BytesIO(bytes(navigation_document)),
+                io.BytesIO(navigation_document.encode('utf-8')),
                 'application/xhtml+xml', is_navigation=True, properties=['nav'])
     items.append(item)
     # Roll through the model list again, making each one an item.
@@ -195,7 +195,7 @@ class DocumentItem(Document):
         nsmap = {'xhtml': "http://www.w3.org/1999/xhtml"}
 
         content = io.BytesIO(
-            b''.join([isinstance(n, str) and n or etree.tostring(n)
+            b''.join([isinstance(n, str) and n.encode('utf-8') or etree.tostring(n)
                       for n in self._html.xpath(content_xpath, namespaces=nsmap)]))
         id = _id_from_metadata(metadata)
         resources = None

--- a/cnxepub/epub.py
+++ b/cnxepub/epub.py
@@ -402,7 +402,7 @@ class Package(Sequence):
         # Write the OPF
         template = jinja2.Template(OPF_TEMPLATE,
                                    trim_blocks=True, lstrip_blocks=True)
-        with open(opf_filepath, 'wb') as opf_file:
+        with open(opf_filepath, 'w') as opf_file:
             opf = template.render(package=package, locations=locations)
             opf_file.write(opf)
 

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -189,7 +189,7 @@ class AdaptationTestCase(unittest.TestCase):
                 namespaces={'xhtml': "http://www.w3.org/1999/xhtml"})[0]
             elm = etree.SubElement(body, "img")
             elm.set('src', internal_uri)
-        with open(item_filepath, 'w') as fb:
+        with open(item_filepath, 'wb') as fb:
             fb.write(etree.tostring(xml))
         item = self.make_item(item_filepath, media_type='application/xhtml+xml')
 
@@ -256,7 +256,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         fs_pointer, epub_filepath = tempfile.mkstemp('.epub')
         self.addCleanup(os.remove, epub_filepath)
         from ..adapters import make_publication_epub
-        with open(epub_filepath, 'w') as epub_file:
+        with open(epub_filepath, 'wb') as epub_file:
             make_publication_epub(binder, 'krabs', '$.$', epub_file)
 
         # Verify the results.
@@ -341,7 +341,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         fs_pointer, epub_filepath = tempfile.mkstemp('.epub')
         self.addCleanup(os.remove, epub_filepath)
         from ..adapters import make_epub
-        with open(epub_filepath, 'w') as epub_file:
+        with open(epub_filepath, 'wb') as epub_file:
             make_epub(binder, epub_file)
 
         # Verify the results.

--- a/cnxepub/tests/test_epub.py
+++ b/cnxepub/tests/test_epub.py
@@ -263,7 +263,8 @@ class WritePackageTestCase(testing.EPUBTestCase):
 
         # Verify...
         walker = os.walk(output_path)
-        root, dirs, files = walker.next()
+        for root, dirs, files in walker:
+            break
         self.assertEqual(['contents', 'resources'], sorted(dirs))
         self.assertEqual([package_name], files)
         # ./contents/
@@ -353,7 +354,8 @@ class WriteEPUBTestCase(testing.EPUBTestCase):
 
         # Verify...
         walker = os.walk(unpack_path)
-        root, dirs, files = walker.next()
+        for root, dirs, files in walker:
+            break
         self.assertEqual(['META-INF', 'contents', 'resources'],
                          sorted(dirs))
         self.assertEqual([package_name, 'mimetype'], sorted(files))

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -26,7 +26,7 @@ class HTMLParsingTestCase(unittest.TestCase):
         with open(html_doc_filepath, 'r') as fb:
             html = etree.parse(fb)
             metadata = parse_metadata(html)
-        summary = """<div xmlns="http://www.w3.org/1999/xhtml" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://dev.w3.org/html5/spec/#custom" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification" class="description" itemprop="description" data-type="description">\n        By the end of this section, you will be able to: \n        <ul class="list">\n          <li class="item">Drive a car</li>\n          <li class="item">Purchase a watch</li>\n          <li class="item">Wear funny hats</li>\n          <li class="item">Eat cake</li>\n        </ul>\n      </div>\n\n      """
+        summary = b"""<div xmlns="http://www.w3.org/1999/xhtml" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://dev.w3.org/html5/spec/#custom" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification" class="description" itemprop="description" data-type="description">\n        By the end of this section, you will be able to: \n        <ul class="list">\n          <li class="item">Drive a car</li>\n          <li class="item">Purchase a watch</li>\n          <li class="item">Wear funny hats</li>\n          <li class="item">Eat cake</li>\n        </ul>\n      </div>\n\n      """
         expected_metadata = {
             'summary': summary,
             'authors': [


### PR DESCRIPTION
`next` for generators have been renamed in python3 to `__next__`.  I
just changed it to use a for loop instead which works in python2 and
python3.

Python3 does not allow mixing str (python2 unicode) and bytes (python2 str).
^ this actually helps getting less unicode decode / encode errors in python 2.
