### PR TITLE
Output DocumentPointer as a xhtml file with a link to the document

### DIFF
--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -79,8 +79,9 @@ class DocumentMetadataParser:
         'cnx-archive-uri',
         )
 
-    def __init__(self, elm_tree):
+    def __init__(self, elm_tree, raise_value_error=True):
        self._xml = elm_tree
+       self.raise_value_error = raise_value_error
 
     def __call__(self):
         return self.metadata
@@ -100,7 +101,8 @@ class DocumentMetadataParser:
                 # raise an error on property access rather than outside of it
                 # as is currently being done here.
                 value = getattr(self, key.replace('-', '_'))
-                if key in self.metadata_required_keys and value is None:
+                if self.raise_value_error and \
+                        key in self.metadata_required_keys and value is None:
                     raise ValueError(
                         "A value for '{}' could not be found.".format(key))
                 elif value is None:
@@ -239,3 +241,18 @@ class DocumentMetadataParser:
         items = self.parse('//xhtml:*[@data-type="cnx-archive-uri"]/@data-value')
         if items:
             return items[0]
+
+
+class DocumentPointerMetadataParser(DocumentMetadataParser):
+    metadata_required_keys = (
+            'title', 'cnx-archive-uri', 'is_document_pointer',
+            )
+    metadata_optional_keys = DocumentMetadataParser.metadata_optional_keys + (
+            'license_url', 'summary',
+            )
+
+    @property
+    def is_document_pointer(self):
+        items = self.parse('//xhtml:*[@data-type="document"]/@data-value')
+        if items:
+            return items[0] == 'pointer'

--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -386,7 +386,7 @@ class Document(object):
         return self._references
 
 
-class DocumentPointer:
+class DocumentPointer(object):
     media_type = 'application/xhtml+xml'
 
     def __init__(self, ident_hash, metadata=None):

--- a/cnxepub/tests/data/loose-pages/content/faux.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/faux.xhtml
@@ -51,6 +51,10 @@
           <a href="mushroom-cloud.xhtml"
              >Da bomb</a>
         </li>
+        <li>
+          <a href="pointer.xhtml"
+             >Pointer</a>
+        </li>
       </ol>
     </nav>
   </body>

--- a/cnxepub/tests/data/loose-pages/content/pointer.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/pointer.xhtml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:epub="http://www.idpf.org/2007/ops"
+      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+      xmlns:dc="http://purl.org/dc/elements/1.1/"
+      xmlns:lrmi="http://lrmi.net/the-specification"
+      >
+  <head itemscope="itemscope"
+        itemtype="http://schema.org/Book"
+        >
+
+    <title>Pointer</title>
+
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML" />
+    <meta itemprop="accessibilityFeature" content="LaTeX" />
+    <meta itemprop="accessibilityFeature" content="alternativeText" />
+    <meta itemprop="accessibilityFeature" content="captions" />
+    <meta itemprop="accessibilityFeature" content="structuredNavigation" />
+
+
+  </head>
+  <body xmlns:bib="http://bibtexml.sf.net/"
+        xmlns:data="http://dev.w3.org/html5/spec/#custom"
+        itemscope="itemscope"
+        itemtype="http://schema.org/Book"
+        >
+    <div data-type="metadata">
+      <h1 data-type="title" itemprop="name">Pointer</h1>
+      <span data-type="document" data-value="pointer" />
+      <span data-type="cnx-archive-uri" data-value="pointer@1" />    </div>
+
+    <div>
+      <p>
+        Click <a href="http://cnx.org/contents/pointer@1">here</a> to read Pointer.
+      </p>
+    </div>
+  </body>
+</html>

--- a/cnxepub/tests/data/loose-pages/faux.opf
+++ b/cnxepub/tests/data/loose-pages/faux.opf
@@ -39,6 +39,10 @@
           media-type="application/xhtml+xml"
           href="content/mushroom-cloud.xhtml"
           />
+    <item id="pointer"
+          media-type="application/xhtml+xml"
+          href="content/pointer.xhtml"
+          />
     <item media-type="image/png"
           href="resources/openstax.png"
           />
@@ -47,5 +51,6 @@
     <itemref linear="no" idref="toc" />
     <itemref linear="yes" idref="fig-bush" />
     <itemref linear="yes" idref="mushroom-cloud" />
+    <itemref linear="yes" idref="pointer" />
   </spine>
 </package>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -108,7 +108,8 @@ class AdaptationTestCase(unittest.TestCase):
             'id': 'subcol',
             'title': "Loose Pages",
             'contents': [{'id': None, 'title': 'Yummy'},
-                         {'id': None, 'title': 'Da bomb'}],
+                         {'id': None, 'title': 'Da bomb'},
+                         {'id': 'pointer@1', 'title': 'Pointer'}],
             }
 
         from ..adapters import adapt_package
@@ -219,6 +220,16 @@ class AdaptationTestCase(unittest.TestCase):
         ref = list(document.references)[0]
         res = list(document.resources)[0]
         self.assertEqual(ref._bound_model, res)
+
+    def test_to_document_pointer(self):
+        """Adapts an ``Item`` to a ``DocumentPointerItem``.
+        Documents are native object representations of data,
+        while the Item is merely a representation of an item
+        in the EPUB structure.
+        """
+        content_filepath = os.path.join(
+                TEST_DATA_DIR, 'loose-pages', 'content',
+                'pointer.xhtml')
 
 
 class ModelsToEPUBTestCase(unittest.TestCase):
@@ -512,6 +523,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         with open(os.path.join(epub_path, 'contents', 'pointer@1.xhtml')) as f:
             pointer = unescape(f.read())
         self.assertTrue('<title>Pointer</title>' in pointer)
+        self.assertTrue('<span data-type="document" data-value="pointer" />' in pointer)
         self.assertTrue('<span data-type="cnx-archive-uri" '
                 'data-value="pointer@1" />' in pointer)
         self.assertTrue('<a href="http://cnx.org/contents/pointer@1">here</a>' in pointer)


### PR DESCRIPTION
Document pointers are pointers to unmodified published documents which
are sometimes included in a book.  An example of this is when you want
to edit the order of documents in a book, you don't need to change the
documents but you need to change the book.

```
DocumentPointer('pointer@1', {
    'title': 'Pointer',
    'cnx-archive-uri': 'pointer@1',
    'url': 'http://cnx.org/contnts/pointer@1',
    })
```

generates a xhtml file that looks like this:

```
<?xml version="1.0" encoding="UTF-8"?>
<html xmlns="http://www.w3.org/1999/xhtml"
      xmlns:epub="http://www.idpf.org/2007/ops"
      xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
      xmlns:dc="http://purl.org/dc/elements/1.1/"
      xmlns:lrmi="http://lrmi.net/the-specification"
      >
  <head itemscope="itemscope"
        itemtype="http://schema.org/Book"
        >

    <title>Pointer</title>

    <!-- These are for discoverability of accessible content. -->
    <meta itemprop="accessibilityFeature" content="MathML" />
    <meta itemprop="accessibilityFeature" content="LaTeX" />
    <meta itemprop="accessibilityFeature" content="alternativeText" />
    <meta itemprop="accessibilityFeature" content="captions" />
    <meta itemprop="accessibilityFeature" content="structuredNavigation" />

  </head>
  <body xmlns:bib="http://bibtexml.sf.net/"
        xmlns:data="http://dev.w3.org/html5/spec/#custom"
        itemscope="itemscope"
        itemtype="http://schema.org/Book"
        >
    <div data-type="metadata">
      <h1 data-type="title" itemprop="name">Pointer</h1>
      <span data-type="document" data-value="pointer" />
      <span data-type="cnx-archive-uri" data-value="pointer@1" />    </div>

    <div>
      <p>
        Click <a href="http://cnx.org/contents/pointer@1">here</a> to read Pointer.
      </p>
    </div>
  </body>
</html>
```
