### PR TITLE
Fix the XPath that parses the copyright-holders from HTML

### DIFF
--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -233,7 +233,7 @@ class DocumentMetadataParser:
 
     @property
     def copyright_holders(self):
-        xpath = '//xhtml:*[@data-type="copyright-holders"]'
+        xpath = '//xhtml:*[@data-type="copyright-holder"]'
         return self._parse_person_info(xpath)
 
     @property

--- a/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
+++ b/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
@@ -122,7 +122,12 @@
           Copyright: 
           <span itemprop="copyrightHolder"
                 data-type="copyright-holder"
-                >Ream</span>
+                >
+            <a href="https://cnx.org/member_profile/ream"
+               itemprop="url"
+               data-type="cnx-id"
+               >Ream</a>
+          </span>
         </p>
         <p class="license">
           Licensed:

--- a/cnxepub/tests/data/loose-pages/content/fig-bush.xhtml
+++ b/cnxepub/tests/data/loose-pages/content/fig-bush.xhtml
@@ -121,7 +121,12 @@
           Copyright: 
           <span itemprop="copyrightHolder"
                 data-type="copyright-holder"
-                >Ream</span>
+                >
+            <a href="https://cnx.org/member_profile/ream"
+               itemprop="url"
+               data-type="cnx-id"
+               >Ream</a>
+          </span>
         </p>
         <p class="license">
           Licensed:

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -45,6 +45,7 @@ def random_extension(*args, **kwargs):
 
 
 class AdaptationTestCase(unittest.TestCase):
+    maxDiff = None
 
     def make_package(self, file):
         from ..epub import Package
@@ -161,7 +162,10 @@ class AdaptationTestCase(unittest.TestCase):
                          {u'id': u'https://example.org/profiles/charrose',
                           u'name': u'Charmaine St. Rose',
                           u'type': u'openstax-id'}],
-            u'copyright_holders': [],
+            u'copyright_holders': [
+                {u'id': u'https://cnx.org/member_profile/ream',
+                 u'name': u'Ream',
+                 u'type': u'cnx-id'}],
             u'created': u'2013/03/19 15:01:16 -0500',
             u'editors': [{u'id': None, u'name': u'I. M. Picky',
                           u'type': None}],

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -16,6 +16,7 @@ TEST_DATA_DIR = os.path.join(here, 'data')
 
 
 class HTMLParsingTestCase(unittest.TestCase):
+    maxDiff = None
 
     def test_metadata_parsing(self):
         """Verify the parsing of metadata from an HTML document."""
@@ -39,7 +40,10 @@ class HTMLParsingTestCase(unittest.TestCase):
                 {'id': 'https://example.org/profiles/charrose',
                  'name': 'Charmaine St. Rose',
                  'type': 'openstax-id'}],
-            'copyright_holders': [],
+            'copyright_holders': [
+                {'id': 'https://cnx.org/member_profile/ream',
+                 'name': 'Ream',
+                 'type': 'cnx-id'}],
             'created': '2013/03/19 15:01:16 -0500',
             'editors': [{'id': None, 'name': 'I. M. Picky', 'type': None}],
             'illustrators': [{'id': None, 'name': 'Francis Hablar',


### PR DESCRIPTION
Fixes #19 
Addresses https://github.com/Connexions/cnx-publishing/issues/64
