### PR TITLE
remove the extra wrapper node, that we add back as body

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -58,6 +58,15 @@ class DocumentContentFormatter(object):
   <body>{}</body>
 </html>""".format(utf8(self.document.content))
         et = etree.HTML(html)
+        # If body now contains a single child, unwrap it
+        body = et.xpath('/html/body')[0]
+        if len(body) == 1:
+            elem = body[0]
+            for child in elem:
+                body.append(child)
+            if elem.text:
+                body.text = elem.text
+            body.remove(elem)
         return etree.tostring(et, pretty_print=True, encoding='utf-8')
 
 

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -336,7 +336,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <body><p>コンテンツ...</p></body>
+  <body>コンテンツ...</body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))
@@ -370,7 +370,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         # Build test document.
         metadata = base_metadata.copy()
         document = Document('title',
-                            io.BytesIO(u'<m:math xmlns:m="http://www.w3.org/1998/Math/MathML"/>'.encode('utf-8')),
+                            io.BytesIO(u'<p><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"/></p>'.encode('utf-8')),
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
@@ -387,7 +387,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <body><p xmlns:m="http://www.w3.org/1998/Math/MathML"><math/></p></body>
+  <body><math/></body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))


### PR DESCRIPTION
DocumentContentFormatter adds a `body` node, to what it epected was an HTML fragment, Since we now store a rooted tree, this removes the top-level node from that tree, in favor of the added body tag.