### PR TITLE
Baking uses the HTMLFormatter - remove the top div there, instead

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,10 +5,10 @@
 
    - feature message
 
-0.16.2
+0.17.0
 ------
 
-- Replicate earlier behavior by removing top node when serializing to HTML
+- Limit Document content to <body> tags only
 
 0.16.1
 ------

--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -524,7 +524,9 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                 if key in ('itemtype', 'itemscope'):
                     child.attrib.pop(key)
 
-            contents = etree.tostring(child)
+            document_body = content_to_etree('')
+            document_body.append(child)
+            contents = etree.tostring(document_body)
             model = {
                 'page': Document,
                 'composite-page': CompositeDocument,

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -21,7 +21,7 @@ from copy import deepcopy
 import requests
 
 from .models import (
-    model_to_tree,
+    model_to_tree, etree_to_content,
     flatten_to_documents,
     Binder, TranslucentBinder,
     Document, DocumentPointer, CompositeDocument, utf8)
@@ -156,11 +156,7 @@ class HTMLFormatter(object):
             else:
                 _html = self.model._xml
 
-            content = ''.join(utf8([
-                               isinstance(node, (type(''), type(b''))) and
-                               node or etree.tostring(node)
-                               for node in _html.xpath('node()')]))
-            return content
+            return etree_to_content(_html, strip_root_node=True)
 
     @property
     def _template(self):

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -159,14 +159,16 @@ class HTMLFormatter(object):
             return tree_to_html(
                 model_to_tree(self.model), self.extensions).decode('utf-8')
         elif isinstance(self.model, Document):
-            content = self.model.content
             if self.generate_ids:
                 _html = deepcopy(self.model._xml)
                 self._generate_ids(self.model, _html)
-                content = ''.join(utf8([
-                                   isinstance(node, (type(''), type(b''))) and
-                                   node or etree.tostring(node)
-                                   for node in _html.xpath('node()')]))
+            else:
+                _html = self.model._xml
+
+            content = ''.join(utf8([
+                               isinstance(node, (type(''), type(b''))) and
+                               node or etree.tostring(node)
+                               for node in _html.xpath('node()')]))
             return content
 
     @property

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -58,15 +58,6 @@ class DocumentContentFormatter(object):
   <body>{}</body>
 </html>""".format(utf8(self.document.content))
         et = etree.HTML(html)
-        # If body now contains a single child, unwrap it
-        body = et.xpath('/html/body')[0]
-        if len(body) == 1:
-            elem = body[0]
-            for child in elem:
-                body.append(child)
-            if elem.text:
-                body.text = elem.text
-            body.remove(elem)
         return etree.tostring(et, pretty_print=True, encoding='utf-8')
 
 

--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -97,7 +97,12 @@ def content_to_etree(content):
         return tree
 
 
-def etree_to_content(etree_):
+def etree_to_content(etree_, strip_root_node=False):
+    if strip_root_node:
+        return ''.join(utf8([
+            isinstance(node, (type(''), type(b''))) and
+            node or etree.tostring(node)
+            for node in etree_.xpath('node()')]))
     return etree.tostring(etree_)
 
 

--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -84,17 +84,16 @@ def utf8(item):
 
 def content_to_etree(content):
     if not content:  # Allow building empty models
-        return etree.XML('<div xmlns="http://www.w3.org/1999/xhtml" />')
+        return etree.XML('<body xmlns="http://www.w3.org/1999/xhtml" />')
     xml_parser = etree.XMLParser(ns_clean=True)
     tree = etree.XML(content, xml_parser)
     # Determine if we've been fed a full XHTML page, with a <body> tag:
     bods = tree.xpath('//*[self::body|self::x:body]',
                       namespaces={'x': 'http://www.w3.org/1999/xhtml'})
     if bods:
-        bods[0].tag = '{http://www.w3.org/1999/xhtml}div'
         return bods[0]
-    else:  # It parsed, so must have been fed a valid XML tree - return it
-        return tree
+    else:
+        raise Exception('Content must have <body>')
 
 
 def etree_to_content(etree_, strip_root_node=False):
@@ -468,7 +467,7 @@ class Document(object):
         self._references = _parse_references(self._xml)
 
     def _content__del(self):
-        self._xml = etree.Element('div')
+        self._xml = content_to_etree('')
 
     content = property(_content__get,
                        _content__set,

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -369,7 +369,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
             egress = unescape(f.read())
         self.assertFalse('<div data-type="resources"' in egress)
         self.assertTrue('<title>egress</title>' in egress)
-        self.assertTrue(u'<p>hüvasti.</p>' in egress)
+        self.assertTrue(u'hüvasti.' in egress)
 
         # Adapt epub back to documents and binders
         from cnxepub import EPUB
@@ -486,7 +486,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         self.assertTrue(re.search(
             '<div data-type="resources"[^>]*>\s*<ul>\s*'
             '<li>\s*<a href="1x1.jpg">1x1.jpg</a>\s*</li>\s*</ul>\s*</div>', egress))
-        self.assertTrue(u'<p><img src="../resources/1x1.jpg"/>hüvasti.</p>' in egress)
+        self.assertTrue(u'<img src="../resources/1x1.jpg"/>hüvasti.' in egress)
 
         # Adapt epub back to documents and binders
         from cnxepub import EPUB
@@ -628,7 +628,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
         self.assertTrue('<title>egress</title>' in egress)
         self.assertTrue('<span data-type="cnx-archive-uri" '
                         'data-value="e78d4f90-e078-49d2-beac-e95e8be70667"' in egress)
-        self.assertTrue(u'<p>hüvasti.</p>' in egress)
+        self.assertTrue(u'hüvasti.' in egress)
         self.assertFalse('Derived from:' in egress)
         self.assertTrue('Derived from:' in ingress)
         self.assertTrue('http://cnx.org/contents/dd68a67a-11f4-4140-a49f-b78e856e2262@1' in ingress)

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -188,13 +188,13 @@ class CollateTestCase(BaseModelTestCase):
             nodes=[
                 self.make_document(
                     id="e78d4f90",
-                    content=b"<p>document one</p>",
+                    content=b"<body><p>document one</p></body>",
                     metadata={'version': '3',
                               'title': "Document One",
                               'license_url': 'http://my.license'}),
                 self.make_document(
                     id="3c448dc6",
-                    content=b"<p>document two</p>",
+                    content=b"<body><p>document two</p></body>",
                     metadata={'version': '1',
                               'title': "Document Two",
                               'license_url': 'http://my.license'})])
@@ -281,13 +281,13 @@ class CollateTestCase(BaseModelTestCase):
             nodes=[
                 self.make_document(
                     id="e78d4f90",
-                    content=b"<span>document one</span>",
+                    content=b"<body><span>document one</span></body>",
                     metadata={'version': '3',
                               'title': "Document One",
                               'license_url': 'http://my.license'}),
                 self.make_document(
                     id="3c448dc6",
-                    content=b"<span>document two</span>",
+                    content=b"<body><span>document two</span></body>",
                     metadata={'version': '1',
                               'title': "Document Two",
                               'license_url': 'http://my.license'})])

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -331,7 +331,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         # Build test document.
         metadata = base_metadata.copy()
         document = Document('title',
-                            io.BytesIO(u'<p>コンテンツ...</p>'.encode('utf-8')),
+                            io.BytesIO(u'<body><p>コンテンツ...</p></body>'.encode('utf-8')),
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
@@ -370,26 +370,21 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         # Build test document.
         metadata = base_metadata.copy()
         document = Document('title',
-                            io.BytesIO(u'<p><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"/></p>'.encode('utf-8')),
+                            io.BytesIO(u'<body><p><m:math xmlns:m="http://www.w3.org/1998/Math/MathML"/></p></body>'.encode('utf-8')),
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <body><p><math xmlns:m="http://www.w3.org/1998/Math/MathML"/></p></body>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML">
+  <body><p><math/></p></body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))
 
         # Second variation. Hoisted namespace declaration
         document = Document('title',
-                            io.BytesIO(u'<p xmlns:m="http://www.w3.org/1998/Math/MathML"><m:math/></p>'.encode('utf-8')),
+                            io.BytesIO(u'<body><p xmlns:m="http://www.w3.org/1998/Math/MathML"><m:math/></p></body>'.encode('utf-8')),
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
-        expected_html = u"""\
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <body><p xmlns:m="http://www.w3.org/1998/Math/MathML"><math/></p></body>
-</html>
-"""
         self.assertEqual(expected_html, unescape(html))
 
 
@@ -398,7 +393,7 @@ class DocumentSummaryFormatterTestCase(unittest.TestCase):
         from ..formatters import DocumentSummaryFormatter
         from ..models import Document
 
-        document = Document('title', io.BytesIO(b'<p>contents</p>'),
+        document = Document('title', io.BytesIO(b'<body><p>contents</p></body>'),
                             metadata={'summary': '<p>résumé</p>'})
         html = str(DocumentSummaryFormatter(document))
         self.assertEqual('<p>résumé</p>', html)
@@ -407,7 +402,7 @@ class DocumentSummaryFormatterTestCase(unittest.TestCase):
         from ..formatters import DocumentSummaryFormatter
         from ..models import Document
 
-        document = Document('title', io.BytesIO(b'<p>contents</p>'),
+        document = Document('title', io.BytesIO(b'<body><p>contents</p></body>'),
                             metadata={'summary': 'résumé'})
         html = str(DocumentSummaryFormatter(document))
         expected = """\
@@ -421,7 +416,7 @@ class DocumentSummaryFormatterTestCase(unittest.TestCase):
         from ..formatters import DocumentSummaryFormatter
         from ..models import Document
 
-        document = Document('title', io.BytesIO(b'<p>contents</p>'),
+        document = Document('title', io.BytesIO(b'<body><p>contents</p></body>'),
                             metadata={'summary': 'résumé<p>etc</p><p>...</p>'})
         html = str(DocumentSummaryFormatter(document))
         expected = """\
@@ -471,7 +466,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         document = Document(
             metadata['title'],
-            io.BytesIO(u'<p>コンテンツ...</p>'.encode('utf-8')),
+            io.BytesIO(u'<body><p>コンテンツ...</p></body>'.encode('utf-8')),
             metadata=metadata)
 
         html = str(HTMLFormatter(document))
@@ -479,7 +474,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
         self.root = etree.fromstring(html.encode('utf-8'))
 
         self.assertIn(u'<title>タイトル</title>', html)
-        self.assertIn(u'コンテンツ...', html)
+        self.assertIn(u'<p>コンテンツ...</p>', html)
 
         self.assertEqual(
             u'タイトル',
@@ -545,7 +540,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
             'derived_from_title': "Taking Customers' Orders",
             })
 
-        binder.append(Document('ingress', io.BytesIO(b'<p>Hello.</p>'),
+        binder.append(Document('ingress', io.BytesIO(b'<body><p>Hello.</p></body>'),
                                metadata=metadata))
 
         translucent_binder = TranslucentBinder(metadata={'title': 'Kranken'})
@@ -556,7 +551,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
             'title': "egress",
             'cnx-archive-uri': 'e78d4f90-e078-49d2-beac-e95e8be70667'})
         translucent_binder.append(
-            Document('egress', io.BytesIO(u'<p>hüvasti.</p>'.encode('utf-8')),
+            Document('egress', io.BytesIO(u'<body><p>hüvasti.</p></body>'.encode('utf-8')),
                      metadata=metadata))
 
         binder.append(DocumentPointer('pointer@1', {
@@ -600,7 +595,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
             'derived_from_title': "Taking Customers' Orders",
             })
 
-        binder.append(Document('ingress', io.BytesIO(b'<p>Hello.</p>'),
+        binder.append(Document('ingress', io.BytesIO(b'<body><p>Hello.</p></body>'),
                                metadata=metadata))
 
         html = str(HTMLFormatter(binder))
@@ -621,10 +616,10 @@ class HTMLFormatterTestCase(unittest.TestCase):
         from ..formatters import HTMLFormatter
 
         random.seed(1)
-        content = """<div>\
+        content = """<body>\
 <div class="title" id="title">Preface</div>
 <p class="para" id="my-id">This thing and <em>that</em> thing.</p>
-<p class="para"><a href="#title">Link</a> to title</p></div>"""
+<p class="para"><a href="#title">Link</a> to title</p></body>"""
         page_one_id = 'fa21215a-91b5-424a-9fbd-5c451f309b87'
 
         expected_content = """\
@@ -676,7 +671,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
 
         metadata = self.base_metadata.copy()
         contents = io.BytesIO(u"""\
-<div>
+<body>
 <h1>Chocolate Desserts</h1>
 <p><a href="#list">List</a> of desserts to try:</p>
 <div data-type="list" id="list"><ul><li>Chocolate Orange Tart,</li>
@@ -684,7 +679,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
 </ul></div><img src="/resources/1x1.jpg" /><p>チョコレートデザート</p>
-</div>
+</body>
 """.encode('utf-8'))
         self.chocolate = Document('chocolate', contents, metadata=metadata,
                                   resources=[jpg])
@@ -692,7 +687,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Apple'
         contents = io.BytesIO(b"""\
-<div>
+<body>
 <h1>Apple Desserts</h1>
 <p><a href="/contents/lemon">Link to lemon</a>. Here are some examples:</p>
 <ul><li id="auto_apple_13436">Apple Crumble,</li>
@@ -701,7 +696,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
-</div>
+</body>
 """)
         self.apple = Document('apple', contents, metadata=metadata)
 
@@ -750,11 +745,11 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Extra Stuff'
         contents = io.BytesIO(b"""\
-<div>
+<body>
 <h1>Extra Stuff</h1>
 <p>This is a composite page.</p>
 <p>Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
-</div>
+</body>
 """)
         self.extra = CompositeDocument(
             'extra', contents, metadata=metadata)

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -479,7 +479,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
         self.root = etree.fromstring(html.encode('utf-8'))
 
         self.assertIn(u'<title>タイトル</title>', html)
-        self.assertIn(u'<p>コンテンツ...</p>', html)
+        self.assertIn(u'コンテンツ...', html)
 
         self.assertEqual(
             u'タイトル',

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -336,7 +336,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <body>コンテンツ...</body>
+  <body><p>コンテンツ...</p></body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))
@@ -375,7 +375,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <body><math xmlns:m="http://www.w3.org/1998/Math/MathML"/></body>
+  <body><p><math xmlns:m="http://www.w3.org/1998/Math/MathML"/></p></body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))
@@ -387,7 +387,7 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
 <html xmlns="http://www.w3.org/1999/xhtml">
-  <body><math/></body>
+  <body><p xmlns:m="http://www.w3.org/1998/Math/MathML"><math/></p></body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))

--- a/cnxepub/tests/test_models.py
+++ b/cnxepub/tests/test_models.py
@@ -321,12 +321,12 @@ class ModelBehaviorTestCase(unittest.TestCase):
                          "../resources/nyan-cat.gif"
                          ]
         content = """\
-<div>
+<body>
 <h1> McDonald Bio </h1>
 <p>There is a farmer named <a href="{}">Old McDonald</a>. Plants grow on his farm and animals live there. He himself is vegan, and so he wrote a book about <a href="{}">Vegan Farming</a>.</p>
 <img src="{}"/>
 <span>Ei ei O.</span>
-</div>
+</body>
 """.format(*expected_uris)
 
         from ..models import Document
@@ -350,12 +350,12 @@ class ModelBehaviorTestCase(unittest.TestCase):
                          "m23409.xhtml",
                          ]
         content = """\
-<div>
+<body>
 <h1>Reference replacement test-case</h1>
 <p>Link to <a href="{}">a local legacy module</a>.</p>
 <img src="{}"/>
 <p>Fin.</p>
-</div>
+</body>
 """.format(*starting_uris)
 
         from ..models import Document


### PR DESCRIPTION
Here's the one-more-hot-fix-fix-fix for the extra div that was breaking all the recipes. Local baking test by Helene seems to be positive.