### PR TITLE
Fix and make the XML squashing function reusable

### DIFF
--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -59,7 +59,6 @@
         </p>
       </div>
       <div class="description" data-type="description" itemprop="description">
-        
         By the end of this section, you will be able to: 
         <ul class="list">
           <li class="item">Drive a car</li>
@@ -68,7 +67,6 @@
           <li class="item">Eat cake</li>
           <li class="item">Bend a spoon</li>
         </ul>
-      
       </div><div data-type="subject" itemprop="about">Science and Mathematics</div>
       <div data-type="resources">
         <ul>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -59,7 +59,6 @@
         </p>
       </div>
       <div class="description" data-type="description" itemprop="description">
-        
         By the end of this section, you will be able to: 
         <ul class="list">
           <li class="item">Drive a car</li>
@@ -68,7 +67,6 @@
           <li class="item">Eat cake</li>
           <li class="item">Bend a spoon</li>
         </ul>
-      
       </div><div data-type="subject" itemprop="about">Science and Mathematics</div>
       <div data-type="resources">
         <ul>

--- a/cnxepub/tests/scripts/test_collated_single_html.py
+++ b/cnxepub/tests/scripts/test_collated_single_html.py
@@ -49,4 +49,7 @@ class CollatedSingleHTMLTestCase(unittest.TestCase):
         self.assertEqual(return_code, 0)
 
         stdout.seek(0)
-        self.assertIn("'title': 'Fruity'", stdout.read())
+        if IS_PY3:
+            self.assertIn("'title': 'Fruity'", stdout.read())
+        else:
+            self.assertIn("'title': u'Fruity'", stdout.read())

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -183,7 +183,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
             u'publishers': [{u'id': None, u'name': u'Ream', u'type': None}],
             u'revised': u'2013/06/18 15:22:55 -0500',
             u'subjects': [u'Science and Mathematics'],
-            u'summary': u'\n        By the end of this section, you will be able to: \n        <ul xmlns="http://www.w3.org/1999/xhtml" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification" class="list">\n          <li class="item">Drive a car</li>\n          <li class="item">Purchase a watch</li>\n          <li class="item">Wear funny hats</li>\n          <li class="item">Eat cake</li>\n        </ul>\n      ',
+            u'summary': u'By the end of this section, you will be able to: \n        <ul xmlns="http://www.w3.org/1999/xhtml" xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:lrmi="http://lrmi.net/the-specification" class="list">\n          <li class="item">Drive a car</li>\n          <li class="item">Purchase a watch</li>\n          <li class="item">Wear funny hats</li>\n          <li class="item">Eat cake</li>\n        </ul>',
             u'title': u'Document One of Infinity',
             u'translators': [{u'id': None, u'name': u'Francis Hablar',
                               u'type': None}],
@@ -778,7 +778,7 @@ Pointer.
                 {
                     'shortId': None,
                     'id': 'chocolate@1.3',
-                    'title': u'\u30c1\u30e7\u30b3\u30ec\u30fc\u30c8'
+                    'title': '&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;'
                 },
                 {
                     'shortId': None,
@@ -851,7 +851,7 @@ Pointer.
                       chocolate.content)
         self.assertIn(b'<div data-type="list" id="list"><ul>',
                       chocolate.content)
-        self.assertEqual(u'チョコレート',
+        self.assertEqual('&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;',
                          desserts.get_title_for_node(chocolate))
 
         extra = desserts[2]

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -757,7 +757,7 @@ Pointer.
                         {
                             'shortId': None,
                             'id': 'lemon@1.3',
-                            'title': '<span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span>'
+                            'title': u'<span>1.1</span> <span>|</span> <span>レモン</span>'
                         },
 
                         {
@@ -778,7 +778,7 @@ Pointer.
                 {
                     'shortId': None,
                     'id': 'chocolate@1.3',
-                    'title': '&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;'
+                    'title': u'チョコレート'
                 },
                 {
                     'shortId': None,
@@ -824,8 +824,8 @@ Pointer.
         self.assertEqual(metadata, lemon_metadata)
         self.assertIn(b'<p id="8271">Yum! <img id="33432" '
                       b'src="/resources/1x1.jpg"/></p>', lemon.content)
-        self.assertEqual('<span>1.1</span> <span>|</span> <span>'
-                         '&#12524;&#12514;&#12531;</span>',
+        self.assertEqual(u'<span>1.1</span> <span>|</span> <span>'
+                         u'レモン</span>',
                          fruity.get_title_for_node(lemon))
 
         citrus = fruity[2]
@@ -851,7 +851,7 @@ Pointer.
                       chocolate.content)
         self.assertIn(b'<div data-type="list" id="list"><ul>',
                       chocolate.content)
-        self.assertEqual('&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;',
+        self.assertEqual(u'チョコレート',
                          desserts.get_title_for_node(chocolate))
 
         extra = desserts[2]

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -59,7 +59,7 @@ class ReconstituteTestCase(unittest.TestCase):
                     {
                     'shortId': None,
                     'id': 'lemon@1.3',
-                    'title': '<span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span>'
+                    'title': u'<span>1.1</span> <span>|</span> <span>レモン</span>'
                     },
                     {
                     'shortId': 'sfE7YYyV@1.3',
@@ -78,7 +78,7 @@ class ReconstituteTestCase(unittest.TestCase):
                     {
                         'shortId': None,
                         'id': 'chocolate@1.3',
-                        'title': '&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;'
+                        'title': u'チョコレート'
                     },
                     {
                         'shortId': None,

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -78,7 +78,7 @@ class ReconstituteTestCase(unittest.TestCase):
                     {
                         'shortId': None,
                         'id': 'chocolate@1.3',
-                        'title': u'\u30c1\u30e7\u30b3\u30ec\u30fc\u30c8'
+                        'title': '&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;'
                     },
                     {
                         'shortId': None,

--- a/cnxepub/tests/test_utils.py
+++ b/cnxepub/tests/test_utils.py
@@ -54,27 +54,28 @@ class TestSquashXMLToText(unittest.TestCase):
         if IS_PY2:
             txt = txt.decode('utf-8')
             expected = expected.decode('utf-8')
-            expected = expected.encode('ascii', 'xmlcharrefreplace')
-        else:
-            expected = expected.encode('ascii', 'xmlcharrefreplace')
-            expected = expected.decode('utf-8')
 
         result = self.target(etree.fromstring(txt, self.parser), True)
-
         assert result == expected
 
     def test_single_elem_only(self):
         txt = '<div><span>Hello Wórld!</span></div>'
-        result = self.target(etree.fromstring(txt), True)
+        expected = '<span>Hello Wórld!</span>'
+        if IS_PY2:
+            txt = txt.decode('utf-8')
+            expected = expected.decode('utf-8')
 
-        expected = '<span>Hello W&#243;rld!</span>'
+        result = self.target(etree.fromstring(txt), True)
         assert result == expected
 
     def test_with_leading_whitespace(self):
         txt = '\n  <div>\n  <span>Hello Wórld!</span>  </div>'
-        result = self.target(etree.fromstring(txt), True)
+        expected = '<span>Hello Wórld!</span>'
+        if IS_PY2:
+            txt = txt.decode('utf-8')
+            expected = expected.decode('utf-8')
 
-        expected = '<span>Hello W&#243;rld!</span>'
+        result = self.target(etree.fromstring(txt), True)
         assert result == expected
 
     def test_with_space_separated_elements(self):
@@ -106,7 +107,10 @@ class TestSquashXMLToText(unittest.TestCase):
             ' Hélène'
             '</div>'
         )
-        result = self.target(etree.fromstring(txt), True)
+        expected = 'Ottó <span>vs</span> Hélène'
+        if IS_PY2:
+            txt = txt.decode('utf-8')
+            expected = expected.decode('utf-8')
 
-        expected = 'Ott&#243; <span>vs</span> H&#233;l&#232;ne'
+        result = self.target(etree.fromstring(txt), True)
         assert result == expected

--- a/cnxepub/tests/test_utils.py
+++ b/cnxepub/tests/test_utils.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+import sys
+import unittest
+
+from lxml import etree
+
+
+IS_PY2 = sys.version_info.major == 2
+
+
+class TestSquashXMLToText(unittest.TestCase):
+
+    content = (
+        '<div data-type="description" xmlns="http://www.w3.org/1999/xhtml">'
+        'FOO '
+        '<p><math xmlns="http://www.w3.org/1998/Math/MathML"/></p>'
+        '<p><math xmlns="http://www.w3.org/1998/Math/MathML"/></p>'
+        ' BAR'
+        '</div>'
+    )
+
+    parser = etree.XMLParser(resolve_entities=True, encoding='ascii')
+
+    def setUp(self):
+        self.content = etree.fromstring(self.content, self.parser)
+
+    @property
+    def target(self):
+        from cnxepub.utils import squash_xml_to_text
+        return squash_xml_to_text
+
+    def test(self):
+        result = self.target(self.content, False)
+
+        expected = (
+            'FOO '
+            '<p xmlns="http://www.w3.org/1999/xhtml">'
+            '<math xmlns="http://www.w3.org/1998/Math/MathML"/></p>'
+            '<p xmlns="http://www.w3.org/1999/xhtml">'
+            '<math xmlns="http://www.w3.org/1998/Math/MathML"/></p>'
+            ' BAR'
+        )
+        assert result == expected
+
+    def test_with_namespace_removal(self):
+        result = self.target(self.content, True)
+
+        expected = 'FOO <p><math/></p><p><math/></p> BAR'
+        assert result == expected
+
+    def test_text_only(self):
+        txt = '<div>Hello Wórld!</div>'
+        expected = 'Hello Wórld!'
+        if IS_PY2:
+            txt = txt.decode('utf-8')
+            expected = expected.decode('utf-8')
+            expected = expected.encode('ascii', 'xmlcharrefreplace')
+        else:
+            expected = expected.encode('ascii', 'xmlcharrefreplace')
+            expected = expected.decode('utf-8')
+
+        result = self.target(etree.fromstring(txt, self.parser), True)
+
+        assert result == expected
+
+    def test_single_elem_only(self):
+        txt = '<div><span>Hello Wórld!</span></div>'
+        result = self.target(etree.fromstring(txt), True)
+
+        expected = '<span>Hello W&#243;rld!</span>'
+        assert result == expected
+
+    def test_with_leading_whitespace(self):
+        txt = '\n  <div>\n  <span>Hello Wórld!</span>  </div>'
+        result = self.target(etree.fromstring(txt), True)
+
+        expected = '<span>Hello W&#243;rld!</span>'
+        assert result == expected
+
+    def test_with_space_separated_elements(self):
+        txt = (
+            '<div>'
+            'count '
+            '<span>1</span>'
+            '<span>,</span> '
+            '<span>2</span>'
+            '<span>,</span> '
+            '... '
+            '<span>10</span> '
+            'stop!'
+            '</div>'
+        )
+        result = self.target(etree.fromstring(txt), True)
+
+        expected = (
+            'count <span>1</span><span>,</span> <span>2</span>'
+            '<span>,</span> ... <span>10</span> stop!'
+        )
+        assert result == expected
+
+    def test_with_buffered_utf8_text(self):
+        txt = (
+            '<div>'
+            'Ottó '
+            '<span>vs</span>'
+            ' Hélène'
+            '</div>'
+        )
+        result = self.target(etree.fromstring(txt), True)
+
+        expected = 'Ott&#243; <span>vs</span> H&#233;l&#232;ne'
+        assert result == expected

--- a/cnxepub/utils.py
+++ b/cnxepub/utils.py
@@ -30,19 +30,14 @@ def squash_xml_to_text(elm, remove_namespaces=False):
     :rtype: str
 
     """
-    result = []
-    if elm.text is not None:
-        # Encode the text as XML entities (e.g. `ó` becomes `&#243;`)
-        # This is done, because etree.tostring without utf-8 encoding
-        # does this by default. We do the same to the text for consistency.
-        text = elm.text.lstrip().encode('ascii', 'xmlcharrefreplace')
-        result.append(text.decode('utf-8'))
+    leading_text = elm.text and elm.text or ''
+    result = [leading_text]
 
     for child in elm.getchildren():
-        # Encoding is not set to utf-8 because otherwise `ó` wouldn't
+        # Encoding is set to utf-8 because otherwise `ó` would
         # become `&#243;`
-        child_value = etree.tostring(child)
-        # Decode to a string and strip the whitespace
+        child_value = etree.tostring(child, encoding='utf-8')
+        # Decode to a string for later regexp and whitespace stripping
         child_value = child_value.decode('utf-8')
         result.append(child_value)
 
@@ -52,5 +47,5 @@ def squash_xml_to_text(elm, remove_namespaces=False):
         result = [re.sub(' xmlns:?[^=]*="[^"]*"', '', v) for v in result]
 
     # Join the results and strip any surrounding whitespace
-    result = ''.join(result).strip()
+    result = u''.join(result).strip()
     return result

--- a/cnxepub/utils.py
+++ b/cnxepub/utils.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# ###
+# Copyright (c) 2019, Rice University
+# This software is subject to the provisions of the GNU Affero General
+# Public License version 3 (AGPLv3).
+# See LICENCE.txt for details.
+# ###
+"""Various standalone utility functions that provide specific outcomes"""
+import re
+
+from lxml import etree
+
+
+__all__ = (
+    'squash_xml_to_text',
+)
+
+
+def squash_xml_to_text(elm, remove_namespaces=False):
+    """Squash the given XML element (as `elm`) to a text containing XML.
+    The outer most element/tag will be removed, but inner elements will
+    remain. If `remove_namespaces` is specified, XML namespace declarations
+    will be removed from the text.
+
+    :param elm: XML element
+    :type elm: :class:`xml.etree.ElementTree`
+    :param remove_namespaces: flag to indicate the removal of XML namespaces
+    :type remove_namespaces: bool
+    :return: the inner text and elements of the given XML element
+    :rtype: str
+
+    """
+    result = []
+    if elm.text is not None:
+        # Encode the text as XML entities (e.g. `ó` becomes `&#243;`)
+        # This is done, because etree.tostring without utf-8 encoding
+        # does this by default. We do the same to the text for consistency.
+        text = elm.text.lstrip().encode('ascii', 'xmlcharrefreplace')
+        result.append(text.decode('utf-8'))
+
+    for child in elm.getchildren():
+        # Encoding is not set to utf-8 because otherwise `ó` wouldn't
+        # become `&#243;`
+        child_value = etree.tostring(child)
+        # Decode to a string and strip the whitespace
+        child_value = child_value.decode('utf-8')
+        result.append(child_value)
+
+    if remove_namespaces:
+        # Best way to remove the namespaces without having the parser complain
+        # about producing invalid XML.
+        result = [re.sub(' xmlns:?[^=]*="[^"]*"', '', v) for v in result]
+
+    # Join the results and strip any surrounding whitespace
+    result = ''.join(result).strip()
+    return result


### PR DESCRIPTION
## What Where Why?

This function plays a huge role in our system because it is responsible for manipulating our content's title and summary (aka abstract). This tests it at a unit-testing level, probably for the first time ever. I do believe it may actually be catching possible future bugs.

## Description

I'm putting this function in a reusable place so that it can be used within Nebuchadnezzar. I've taken liberties to fix many problems with it along the way. From duplicating ending text, so not html entity encoding text that doesn't have html.

### UTF-8 instead of XML entities

The decision to encode all text as UTF-8 was made. This means XML entities no longer appear in the resulting snippet. This was happening in several places within the tests. At the same time it wasn't happening in other places. Webview does have the `<meta charset="utf-8">` in the page, so we should be fine to support straight up UTF-8 text. Worst case, we can switch it back (see my second commit).

It does bring up a point that I'm sure Phil has made several times over. That is, we don't have a unified way of parsing our XML. That should really be addressed.

### Leading and trailing whitespace

This removes white space around the content. This wasn't necessarily a problem, but it does now provide consistent output.

### Now handles math

I didn't see any tests that specifically looked at math in relation to this squashing functionality. Those tests are now included and seem to be handled correctly with the absence of a parent element.

