### PR TITLE
Fix longdesc resource handling

### DIFF
--- a/cnxepub/models.py
+++ b/cnxepub/models.py
@@ -297,19 +297,23 @@ class HTMLReferenceFinder(object):
     def _media(self):
         media_xpath = [
                 ['//img[@src]', 'src', None],
+                ['//img[@longdesc]', 'longdesc', None],
                 ['//audio[@src]', 'src', None],
                 ['//video[@src]', 'src', None],
                 ['//object[@data]', 'data', None],
                 ['//object/embed[@src]', 'src', None],
                 ['//source[@src]', 'src', None],
                 ['//span[@data-src]', 'data-src', None],
+                ['//span[@data-longdesc]', 'data-longdesc', None],
                 ['//x:img[@src]', 'src', XHTML_NS],
+                ['//x:img[@longdesc]', 'longdesc', XHTML_NS],
                 ['//x:audio[@src]', 'src', XHTML_NS],
                 ['//x:video[@src]', 'src', XHTML_NS],
                 ['//x:object[@data]', 'data', XHTML_NS],
                 ['//x:object/embed[@src]', 'src', XHTML_NS],
                 ['//x:source[@src]', 'src', XHTML_NS],
                 ['//x:span[@data-src]', 'data-src', XHTML_NS],
+                ['//x:span[@data-longdesc]', 'data-longdesc', XHTML_NS],
                 ]
         for xpath, attr, ns in media_xpath:
             for elm in self.apply_xpath(xpath, ns):

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -420,7 +420,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
             jpg = Resource('1x1.jpg', io.BytesIO(f.read()), 'image/jpeg',
                            filename='1x1.jpg')
         binder.append(Document('egress', io.BytesIO(
-            u'<body><p><img src="1x1.jpg" />hüvasti.</p></body>'.encode('utf-8')),
+            u'<body><p><img src="1x1.jpg" />hüvasti.</p><p><img longdesc="1x1.jpg" src="1x1.jpg" />hüvastilongdesc.</p></body>'.encode('utf-8')),
                                metadata=metadata,
                                resources=[jpg]))
 
@@ -487,6 +487,7 @@ class ModelsToEPUBTestCase(unittest.TestCase):
             '<div data-type="resources"[^>]*>\s*<ul>\s*'
             '<li>\s*<a href="1x1.jpg">1x1.jpg</a>\s*</li>\s*</ul>\s*</div>', egress))
         self.assertTrue(u'<p><img src="../resources/1x1.jpg"/>hüvasti.</p>' in egress)
+        self.assertTrue(u'<p><img longdesc="../resources/1x1.jpg" src="../resources/1x1.jpg"/>hüvastilongdesc.</p>' in egress)
 
         # Adapt epub back to documents and binders
         from cnxepub import EPUB


### PR DESCRIPTION
Handle `longdesc` like `src` as resources.

See https://github.com/openstax/rhaptos.cnxmlutils/issues/172 for details.