### PR TITLE
improve readme for python 3 usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ Library for parsing and building EPUB3 files for connexions content.
 Getting started
 ---------------
 
-Prerequisites needed e.g. on Ubuntu Linux ``sudo apt install python-dev libicu-dev``
+Prerequisites needed e.g. on Ubuntu Linux ``sudo apt install build-essential python-dev python3-dev libicu-dev``
 
 To install::
 


### PR DESCRIPTION
`cnx-epub-validate-collated` needs python3 because it will fail on python2 (unicode errors).
I've updated the documentation for that reason.