### PR TITLE
Change _fix_namespaces to not remove xml comments

### DIFF
--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -1,19 +1,18 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta content="en" data-type="language" itemprop="inLanguage"/>
+    <meta itemprop="inLanguage" data-type="language" content="en"/>
 
-    
-    <meta content="MathML" itemprop="accessibilityFeature"/>
-    <meta content="LaTeX" itemprop="accessibilityFeature"/>
-    <meta content="alternativeText" itemprop="accessibilityFeature"/>
-    <meta content="captions" itemprop="accessibilityFeature"/>
-    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta content="2013/03/19 15:01:16 -0500" itemprop="dateCreated"/>
-    <meta content="2013/06/18 15:22:55 -0500" itemprop="dateModified"/>
+    <meta itemprop="dateCreated" content="2013/03/19 15:01:16 -0500"/>
+    <meta itemprop="dateModified" content="2013/06/18 15:22:55 -0500"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
@@ -22,43 +21,43 @@
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="None" href="None" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="None" itemprop="url" data-type="None">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         By the end of this section, you will be able to: 
         <ul class="list">
           <li class="item">Drive a car</li>
@@ -67,20 +66,20 @@
           <li class="item">Eat cake</li>
           <li class="item">Bend a spoon</li>
         </ul>
-      </div><div data-type="subject" itemprop="about">Science and Mathematics</div>
+      </div><div itemprop="about" data-type="subject">Science and Mathematics</div>
       <div data-type="resources">
         <ul>
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
+   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3" cnx-archive-shortid="541PkOB4@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3" cnx-archive-shortid="541PkOB4@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3" cnx-archive-shortid="541PkOB4@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
   <div data-type="unit"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
@@ -90,44 +89,44 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Chapter One</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="derived-from">
         Derived from:
-        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
+        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -136,17 +135,17 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
-      </div><div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>    </div>
 
    
-    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_13436">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
@@ -159,44 +158,44 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Chapter Two</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="derived-from">
         Derived from:
-        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
+        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -205,17 +204,17 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
-      </div><div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>    </div>
 
    
-    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_76378">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
@@ -228,7 +227,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
@@ -238,44 +237,44 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Chapter Three</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="derived-from">
         Derived from:
-        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
+        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -284,17 +283,17 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
-      </div><div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>    </div>
 
    
-    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_49544">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -1,19 +1,18 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Book of Infinity</title>
-    <meta content="en" data-type="language" itemprop="inLanguage"/>
+    <meta itemprop="inLanguage" data-type="language" content="en"/>
 
-    
-    <meta content="MathML" itemprop="accessibilityFeature"/>
-    <meta content="LaTeX" itemprop="accessibilityFeature"/>
-    <meta content="alternativeText" itemprop="accessibilityFeature"/>
-    <meta content="captions" itemprop="accessibilityFeature"/>
-    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta content="2013/03/19 15:01:16 -0500" itemprop="dateCreated"/>
-    <meta content="2013/06/18 15:22:55 -0500" itemprop="dateModified"/>
+    <meta itemprop="dateCreated" content="2013/03/19 15:01:16 -0500"/>
+    <meta itemprop="dateModified" content="2013/06/18 15:22:55 -0500"/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
@@ -22,43 +21,43 @@
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="None" href="None" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="None" itemprop="url" data-type="None">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         By the end of this section, you will be able to: 
         <ul class="list">
           <li class="item">Drive a car</li>
@@ -67,20 +66,20 @@
           <li class="item">Eat cake</li>
           <li class="item">Bend a spoon</li>
         </ul>
-      </div><div data-type="subject" itemprop="about">Science and Mathematics</div>
+      </div><div itemprop="about" data-type="subject">Science and Mathematics</div>
       <div data-type="resources">
         <ul>
 <li><a href="cover.png">book-cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-shortid="541PkOB4@3" cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
+   <nav id="toc"><ol><li><span>Part One</span><ol><li><span>Chapter One</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3" cnx-archive-shortid="541PkOB4@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a></li></ol></li><li><span>Chapter Two</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3" cnx-archive-shortid="541PkOB4@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (again)</a></li></ol></li></ol></li><li><span>Part Two</span><ol><li><span>Chapter Three</span><ol><li cnx-archive-uri="e78d4f90-e078-49d2-beac-e95e8be70667@3" cnx-archive-shortid="541PkOB4@3"><a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One (...and again)</a></li></ol></li></ol></li></ol></nav>
   <div data-type="unit"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Part One</h1>
       <span data-type="binding" data-value="translucent"/>
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
@@ -90,44 +89,44 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter One</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Chapter One</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="derived-from">
         Derived from:
-        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
+        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -136,17 +135,17 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
-      </div><div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>    </div>
 
    
-    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_17611">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
@@ -159,44 +158,44 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Two</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Chapter Two</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="derived-from">
         Derived from:
-        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
+        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -205,17 +204,17 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
-      </div><div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>    </div>
 
    
-    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_8271">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
@@ -228,7 +227,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
@@ -238,44 +237,44 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
+          <a href="http://creativecommons.org/licenses/by/3.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">This work is shared with the public using the Attribution 3.0 Unported (CC BY 3.0) license.</a>
         </p>
       </div>    </div>
 
-   <h1 data-type="document-title">Chapter Three</h1><div class="fruity" data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Chapter Three</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="github-id" href="https://github.com/marknewlyn" itemprop="url">Mark Horner</a>
-          </span>, <span data-type="author" id="author-2" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="https://cnx.org/member_profile/sarblyth" itemprop="url">Sarah Blyth</a>
-          </span>, <span data-type="author" id="author-3" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="openstax-id" href="https://example.org/profiles/charrose" itemprop="url">Charmaine St. Rose</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://github.com/marknewlyn" itemprop="url" data-type="github-id">Mark Horner</a>
+          </span>, <span id="author-2" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://cnx.org/member_profile/sarblyth" itemprop="url" data-type="cnx-id">Sarah Blyth</a>
+          </span>, <span id="author-3" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="https://example.org/profiles/charrose" itemprop="url" data-type="openstax-id">Charmaine St. Rose</a>
           </span>
         Edited by:
-            <span data-type="editor" id="editor-1" itemprop="editor" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">I. M. Picky</a>
+            <span id="editor-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="editor" data-type="editor">
+              <a href="None" itemprop="url" data-type="None">I. M. Picky</a>
             </span>
         Illustrated by:
-            <span data-type="illustrator" id="illustrator-1" itemprop="illustrator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="illustrator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="illustrator" data-type="illustrator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
         Translated by:
-            <span data-type="translator" id="translator-1" itemprop="translator" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Francis Hablar</a>
+            <span id="translator-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="translator" data-type="translator">
+              <a href="None" itemprop="url" data-type="None">Francis Hablar</a>
             </span>
       </div>
       <div class="publishers">
         Published By:
-            <span data-type="publisher" id="publisher-1" itemprop="publisher" itemscope="itemscope" itemtype="http://schema.org/Person">
-              <a data-type="None" href="None" itemprop="url">Ream</a>
+            <span id="publisher-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="publisher" data-type="publisher">
+              <a href="None" itemprop="url" data-type="None">Ream</a>
             </span>      </div>
       <div class="derived-from">
         Derived from:
-        <a data-type="derived-from" href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL">Wild Grains and Warted Feet</a>
+        <a href="http://example.org/contents/id@ver" itemprop="isDerivedFromURL" data-type="derived-from">Wild Grains and Warted Feet</a>
       </div>
       <div class="print-style">
         Print style:
@@ -284,17 +283,17 @@
       <div class="permissions">
         <p class="copyright">
           Copyright:
-              <span data-type="copyright-holder" id="copyright-holder-1" itemprop="copyright-holder" itemscope="itemscope" itemtype="http://schema.org/Person">
-                <a data-type="cnx-id" href="https://cnx.org/member_profile/ream" itemprop="url">Ream</a>
+              <span id="copyright-holder-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="copyright-holder" data-type="copyright-holder">
+                <a href="https://cnx.org/member_profile/ream" itemprop="url" data-type="cnx-id">Ream</a>
               </span>        </p>
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
-      </div><div data-type="keyword" itemprop="keywords">South Africa</div><div data-type="subject" itemprop="about">Science and Mathematics</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">South Africa</div><div itemprop="about" data-type="subject">Science and Mathematics</div>    </div>
 
    
-    
+    <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
     <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_15455">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -12,6 +12,7 @@
       data-type='language'
       itemprop='inLanguage'
     ></meta>
+<!-- These are for discoverability of accessible content. -->
     <meta
       content='MathML'
       itemprop='accessibilityFeature'

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -13,6 +13,7 @@
       data-type='language'
       itemprop='inLanguage'
     ></meta>
+<!-- These are for discoverability of accessible content. -->
     <meta
       content='MathML'
       itemprop='accessibilityFeature'

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -1,19 +1,18 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML" lang="en">
-  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+<html xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1999/xhtml" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="en" data-type="language" itemprop="inLanguage"/>
+    <meta itemprop="inLanguage" data-type="language" content="en"/>
 
-    
-    <meta content="MathML" itemprop="accessibilityFeature"/>
-    <meta content="LaTeX" itemprop="accessibilityFeature"/>
-    <meta content="alternativeText" itemprop="accessibilityFeature"/>
-    <meta content="captions" itemprop="accessibilityFeature"/>
-    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta content="" itemprop="dateCreated"/>
-    <meta content="" itemprop="dateModified"/>
+    <meta itemprop="dateCreated" content=""/>
+    <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
@@ -23,7 +22,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
       <div data-type="resources">
@@ -31,7 +30,7 @@
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
@@ -39,7 +38,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>    </div>
 
@@ -48,8 +47,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -61,12 +60,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Apple Desserts</h1>
@@ -81,13 +80,13 @@
 </ul>
 
 
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+  </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -99,12 +98,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
@@ -113,7 +112,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_8271">Yum! <img id="auto_lemon_33432" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_8271">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_33432"/></p>
 
 <div data-type="exercise" id="auto_lemon_15455">
     <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
@@ -155,8 +154,8 @@
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -168,20 +167,20 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -193,12 +192,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
@@ -207,7 +206,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_58915">Yum! <img id="auto_lemon_61898" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_58915">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_61898"/></p>
 
 <div data-type="exercise" id="auto_lemon_85405">
     <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
@@ -249,8 +248,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -262,12 +261,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
@@ -282,7 +281,7 @@
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_63944"/><p id="auto_chocolate_3715">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -290,8 +289,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -303,12 +302,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Extra Stuff</h1>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -1,19 +1,18 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="en" data-type="language" itemprop="inLanguage"/>
+    <meta itemprop="inLanguage" data-type="language" content="en"/>
 
-    
-    <meta content="MathML" itemprop="accessibilityFeature"/>
-    <meta content="LaTeX" itemprop="accessibilityFeature"/>
-    <meta content="alternativeText" itemprop="accessibilityFeature"/>
-    <meta content="captions" itemprop="accessibilityFeature"/>
-    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta content="" itemprop="dateCreated"/>
-    <meta content="" itemprop="dateModified"/>
+    <meta itemprop="dateCreated" content=""/>
+    <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
@@ -23,7 +22,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
       <div data-type="resources">
@@ -31,7 +30,7 @@
 <li><a href="cover.png">COVER.PNG</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
@@ -39,7 +38,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>    </div>
 
@@ -48,8 +47,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -61,12 +60,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Apple Desserts</h1>
@@ -81,13 +80,13 @@
 </ul>
 
 
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+  </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -99,12 +98,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
@@ -113,7 +112,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_8271">Yum! <img id="auto_lemon_33432" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_8271">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_33432"/></p>
 
 <div data-type="exercise" id="auto_lemon_15455">
     <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
@@ -142,8 +141,8 @@
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -155,20 +154,20 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -180,12 +179,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
@@ -194,7 +193,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_58915">Yum! <img id="auto_lemon_61898" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_58915">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_61898"/></p>
 
 <div data-type="exercise" id="auto_lemon_85405">
     <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
@@ -223,8 +222,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -236,12 +235,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">SMALL.JPG</a></li>        </ul>
@@ -256,7 +255,7 @@
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_63944"/><p id="auto_chocolate_3715">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -264,8 +263,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">GOOD FOOD</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">GOOD FOOD</a>
           </span>
         Edited by:
 
@@ -277,12 +276,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-BY 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-BY 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Extra Stuff</h1>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -1,19 +1,18 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="en" data-type="language" itemprop="inLanguage"/>
+    <meta itemprop="inLanguage" data-type="language" content="en"/>
 
-    
-    <meta content="MathML" itemprop="accessibilityFeature"/>
-    <meta content="LaTeX" itemprop="accessibilityFeature"/>
-    <meta content="alternativeText" itemprop="accessibilityFeature"/>
-    <meta content="captions" itemprop="accessibilityFeature"/>
-    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta content="" itemprop="dateCreated"/>
-    <meta content="" itemprop="dateModified"/>
+    <meta itemprop="dateCreated" content=""/>
+    <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
@@ -23,7 +22,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
       <div data-type="resources">
@@ -31,7 +30,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
@@ -39,7 +38,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>    </div>
 
@@ -48,8 +47,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -61,12 +60,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Apple Desserts</h1>
@@ -81,13 +80,13 @@
 </ul>
 
 
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+  </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -99,12 +98,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -113,7 +112,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_76378">Yum! <img id="auto_lemon_25507" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_76378">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_25507"/></p>
 
 <div data-type="exercise" id="auto_lemon_49544">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
@@ -139,8 +138,8 @@
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -152,20 +151,20 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -177,12 +176,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -191,7 +190,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_78873">Yum! <img id="auto_lemon_9386" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_78873">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_9386"/></p>
 
 <div data-type="exercise" id="auto_lemon_2834">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
@@ -217,8 +216,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -230,12 +229,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -250,7 +249,7 @@
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img id="auto_chocolate_210" src="/resources/1x1.jpg"/><p id="auto_chocolate_44539">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_210"/><p id="auto_chocolate_44539">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -258,8 +257,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -271,12 +270,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Extra Stuff</h1>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -1,19 +1,18 @@
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head itemscope="itemscope" itemtype="http://schema.org/Book">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
-    <meta content="en" data-type="language" itemprop="inLanguage"/>
+    <meta itemprop="inLanguage" data-type="language" content="en"/>
 
-    
-    <meta content="MathML" itemprop="accessibilityFeature"/>
-    <meta content="LaTeX" itemprop="accessibilityFeature"/>
-    <meta content="alternativeText" itemprop="accessibilityFeature"/>
-    <meta content="captions" itemprop="accessibilityFeature"/>
-    <meta content="structuredNavigation" itemprop="accessibilityFeature"/>
+    <!-- These are for discoverability of accessible content. -->
+    <meta itemprop="accessibilityFeature" content="MathML"/>
+    <meta itemprop="accessibilityFeature" content="LaTeX"/>
+    <meta itemprop="accessibilityFeature" content="alternativeText"/>
+    <meta itemprop="accessibilityFeature" content="captions"/>
+    <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta content="" itemprop="dateCreated"/>
-    <meta content="" itemprop="dateModified"/>
+    <meta itemprop="dateCreated" content=""/>
+    <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
@@ -23,7 +22,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
       <div data-type="resources">
@@ -31,7 +30,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"/>
@@ -39,7 +38,7 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>    </div>
 
@@ -48,8 +47,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -61,12 +60,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Apple Desserts</h1>
@@ -81,13 +80,13 @@
 </ul>
 
 
-  </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+  </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -99,12 +98,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -113,7 +112,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_8271">Yum! <img id="auto_lemon_33432" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_8271">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_33432"/></p>
 
 <div data-type="exercise" id="auto_lemon_15455">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
@@ -139,8 +138,8 @@
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -152,20 +151,20 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
-   <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata" style="display: none;">
+   <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -177,12 +176,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -191,7 +190,7 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_58915">Yum! <img id="auto_lemon_61898" src="/resources/1x1.jpg"/></p>
+<p id="auto_lemon_58915">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_61898"/></p>
 
 <div data-type="exercise" id="auto_lemon_85405">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
@@ -217,8 +216,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -230,12 +229,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>
       <div data-type="resources">
         <ul>
 <li><a href="1x1.jpg">small.jpg</a></li>        </ul>
@@ -250,7 +249,7 @@
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img id="auto_chocolate_63944" src="/resources/1x1.jpg"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_63944"/><p id="auto_chocolate_3715">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -258,8 +257,8 @@
 
       <div class="authors">
         By:
-<span data-type="author" id="author-1" itemprop="author" itemscope="itemscope" itemtype="http://schema.org/Person">
-            <a data-type="cnx-id" href="yum" itemprop="url">Good Food</a>
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
           </span>
         Edited by:
 
@@ -271,12 +270,12 @@
       <div class="permissions">
         <p class="license">
           Licensed:
-          <a data-type="license" href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL">CC-By 4.0</a>
+          <a href="http://creativecommons.org/licenses/by/4.0/" itemprop="dc:license,lrmi:useRightsURL" data-type="license">CC-By 4.0</a>
         </p>
       </div>
-      <div class="description" data-type="description" itemprop="description">
+      <div class="description" itemprop="description" data-type="description">
         <p>summary</p>
-      </div><div data-type="keyword" itemprop="keywords">Food</div><div data-type="keyword" itemprop="keywords">デザート</div><div data-type="keyword" itemprop="keywords">Pudding</div><div data-type="subject" itemprop="about">Humanities</div>    </div>
+      </div><div itemprop="keywords" data-type="keyword">Food</div><div itemprop="keywords" data-type="keyword">デザート</div><div itemprop="keywords" data-type="keyword">Pudding</div><div itemprop="about" data-type="subject">Humanities</div>    </div>
 
    
 <h1>Extra Stuff</h1>

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -823,8 +823,8 @@ Pointer.
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, lemon_metadata)
-        self.assertIn(b'<p id="8271">Yum! <img id="33432" '
-                      b'src="/resources/1x1.jpg"/></p>', lemon.content)
+        self.assertIn(b'<p id="8271">Yum! <img src="/resources/1x1.jpg" '
+                      b'id="33432"/></p>', lemon.content)
         self.assertEqual(u'<span>1.1</span> <span>|</span> <span>'
                          u'レモン</span>',
                          fruity.get_title_for_node(lemon))

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -335,8 +335,8 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
-<html xmlns="http://www.w3.org/1999/xhtml">
-  <body><p>コンテンツ...</p></body>
+<html xmlns="http://www.w3.org/1999/xhtml">\
+<body><p>コンテンツ...</p></body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))
@@ -374,8 +374,8 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML">
-  <body><p><math/></p></body>
+<html xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1999/xhtml">\
+<body><p><math/></p></body>
 </html>
 """
         self.assertEqual(expected_html, unescape(html))
@@ -918,3 +918,30 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
 
         # After assert, so won't clean up if test fails
         os.remove(out_path)
+
+
+class FixNamespacesTestCase(unittest.TestCase):
+    def test(self):
+        from ..formatters import _fix_namespaces
+
+        actual = _fix_namespaces("""\
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+    <body xmlns:bib="http://bibtexml.sf.net/">
+        <p>Some text<em><!-- no-selfclose --></em>!</p>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <mtext>H</mtext>
+        </math>
+    </body>
+</html>""").decode('utf-8')
+        expected_content = """\
+<html xmlns:m="http://www.w3.org/1998/Math/MathML"\
+ xmlns="http://www.w3.org/1999/xhtml" lang="en">\
+<body>
+        <p>Some text<em><!-- no-selfclose --></em>!</p>
+        <m:math>
+            <m:mtext>H</m:mtext>
+        </m:math>
+    </body>
+</html>
+"""
+        self.assertMultiLineEqual(expected_content, actual)


### PR DESCRIPTION
The xml comments, `<!-- no-selfclose -->` are added into
rhaptos.cnxmlutils in order to avoid self closing tags in our html, in
an attempt to make the xhtml output somewhat HTML5 compatible.

`cnxepub.formatters._fix_namespaces` tidies up the namespaces by putting
everything in the root tag.  It uses the python built-in
`xml.etree.ElementTree` library to do that.  The `xml.etree.ElementTree`
library skips xml comments.

From the python docs
https://docs.python.org/3.7/library/xml.etree.elementtree.html#module-xml.etree.ElementTree
(the 2.7 docs doesn't have this):

> Note: Not all elements of the XML input will end up as elements of the
> parsed tree. Currently, this module skips over any XML comments,
> processing instructions, and document type declarations in the input.

So switch from `xml.etree.ElementTree` to `lxml.etree` to preserve xml
comments.

`lxml.etree` also has `register_namespace`, but it doesn't allow a
default namespace.  So what I've done is to parse the document, create a
new root tag that's exactly the same as the old one but with the right
nsmap.

https://stackoverflow.com/questions/11346480/lxml-add-namespace-to-input-file