### PR TITLE
Use xmlpp to standardize html test output (lxml upgrade)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 sudo: false
 python:
   - "2.7"
-  - "3.5"
+  - "3.6"
 services:
   - memcached
 before_install:
@@ -11,8 +11,6 @@ before_install:
   - pip --version
   - pip install coverage
   - pip install codecov
-  # FIXME travis fails w/ 3.7.0 on python3, even though it works locally
-  - pip install lxml==3.6.4
   # Install cnx-easybake
   - pip install git+https://github.com/openstax/cnx-cssselect2.git#egg=cnx-cssselect2
   - pip install git+https://github.com/Connexions/cnx-easybake.git#egg=cnx-easybake

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -1,4 +1,4 @@
-<html xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1999/xhtml" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML" lang="en"><head itemscope="itemscope" itemtype="http://schema.org/Book">
 
     <title>Desserts</title>
     <meta itemprop="inLanguage" data-type="language" content="en"/>

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -374,18 +374,29 @@ class DocumentContentFormatterTestCase(unittest.TestCase):
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
         expected_html = u"""\
-<html xmlns:m="http://www.w3.org/1998/Math/MathML" xmlns="http://www.w3.org/1999/xhtml">\
-<body><p><math/></p></body>
+<html
+  xmlns='http://www.w3.org/1999/xhtml'
+  xmlns:m='http://www.w3.org/1998/Math/MathML'
+>
+  <body>
+    <p>
+      <math></math>
+    </p>
+  </body>
 </html>
 """
-        self.assertEqual(expected_html, unescape(html))
+        self.assertMultiLineEqual(
+            expected_html,
+            xmlpp(unescape(html).encode('utf-8')).decode('utf-8'))
 
         # Second variation. Hoisted namespace declaration
         document = Document('title',
                             io.BytesIO(u'<body><p xmlns:m="http://www.w3.org/1998/Math/MathML"><m:math/></p></body>'.encode('utf-8')),
                             metadata=metadata)
         html = str(DocumentContentFormatter(document))
-        self.assertEqual(expected_html, unescape(html))
+        self.assertMultiLineEqual(
+            expected_html,
+            xmlpp(unescape(html).encode('utf-8')).decode('utf-8'))
 
 
 class DocumentSummaryFormatterTestCase(unittest.TestCase):
@@ -932,16 +943,22 @@ class FixNamespacesTestCase(unittest.TestCase):
             <mtext>H</mtext>
         </math>
     </body>
-</html>""").decode('utf-8')
+</html>""")
         expected_content = """\
-<html xmlns:m="http://www.w3.org/1998/Math/MathML"\
- xmlns="http://www.w3.org/1999/xhtml" lang="en">\
-<body>
-        <p>Some text<em><!-- no-selfclose --></em>!</p>
-        <m:math>
-            <m:mtext>H</m:mtext>
-        </m:math>
-    </body>
+<html
+  lang='en'
+  xmlns='http://www.w3.org/1999/xhtml'
+  xmlns:m='http://www.w3.org/1998/Math/MathML'
+>
+  <body>
+    <p>Some text
+      <em><!-- no-selfclose --></em>!
+    </p>
+    <m:math>
+      <m:mtext>H</m:mtext>
+    </m:math>
+  </body>
 </html>
 """
-        self.assertMultiLineEqual(expected_content, actual)
+        self.maxDiff = None
+        self.assertMultiLineEqual(expected_content, xmlpp(actual).decode('utf-8'))


### PR DESCRIPTION
According to Thomas who originally reported this bug, with `lxml>=4.4`,
the tests failed.  It appears to only affect python 3 and the only
difference is `xmlns="http://www.w3.org/1999/xhtml"` now goes before
`xmlns:m="http://www.w3.org/1998/Math/MathML">`.

Since it's different for python 2 and python 3, I decided to use `xmlpp`
to standardize the output to avoid this kind of failure in the future.

---

Change travis to use 3.6 and not pin lxml

Python 3.6 is what ubuntu 18.04 is using for python 3 anyway, so time to
update the version.

There was a time when lxml 3.7.0 didn't work with python 3 on travis but
lxml is now on 4.4.1, it's time to remove this from `.travis.yml`.
