### PR TITLE
Add exercise stimulus if provided

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -459,6 +459,9 @@ def exercise_callback_factory(match, url_template,
 #  src/scripts/modules/media/embeddables/exercise-template.html
 
 EXERCISE_TEMPLATE = jinja2.Template("""\
+{% if data['items'].0.stimulus_html %}
+    <div class="exercise-stimulus">{{ data['items'].0.stimulus_html }}</div>
+{% endif %}
 {% if data['items'].0.questions %}
     {% for question in data['items'].0.questions %}
         <div>{{ question.stem_html }}</div>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -380,6 +380,13 @@
           data-type='exercise'
           id='auto_lemon_49544'
         >
+          <div
+            class="exercise-stimulus"
+          >
+            <p>
+              Please answer the following question:
+            </p>
+          </div>
           <div>Dehydration
             <img
               href='none'
@@ -629,6 +636,13 @@
             data-type='exercise'
             id='auto_lemon_2834'
           >
+            <div
+              class="exercise-stimulus"
+            >
+              <p>
+                Please answer the following question:
+              </p>
+            </div>
             <div>Dehydration
               <img
                 href='none'

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -115,7 +115,8 @@
 <p id="auto_lemon_8271">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_33432"/></p>
 
 <div data-type="exercise" id="auto_lemon_15455">
-    <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
+    <div class="exercise-stimulus"><p>Please answer the following question:</p></div>
+        <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
             <ol data-number-style="lower-alpha">
                     <li data-correctness="0.0">monomers</li>
                     <li data-correctness="1.0">polymers (<span data-math="retry"/>)</li>
@@ -209,7 +210,8 @@
 <p id="auto_lemon_58915">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_61898"/></p>
 
 <div data-type="exercise" id="auto_lemon_85405">
-    <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
+    <div class="exercise-stimulus"><p>Please answer the following question:</p></div>
+        <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
             <ol data-number-style="lower-alpha">
                     <li data-correctness="0.0">monomers</li>
                     <li data-correctness="1.0">polymers (<span data-math="retry"/>)</li>

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -78,7 +78,7 @@ EXERCISE_JSON_HTML = {
          "number": 93,
          "editors": [],
          "is_vocab": False,
-         "stimulus_html": "",
+         "stimulus_html": "<p>Please answer the following question:</p>",
          "questions": [
             {
                "stimulus_html": "",


### PR DESCRIPTION
This change adds to the template for exercises pulled from a request in order to display an exercise stimulus for a multi-part exercise if one is provided.

I also added an exercise stimulus to one of the two existing tests that pull the json.