### PR TITLE
Include exercise id if math in exercise raises XMLSyntaxError

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -388,7 +388,8 @@ def _replace_tex_math(exercise_id, node, mml_url, mc_client=None, retry=0):
                        '{}'.format(json.dumps(eq, indent=4)))
         retry += 1
         if retry < 2:
-            return _replace_tex_math(node, mml_url, mc_client, retry)
+            return _replace_tex_math(exercise_id, node, mml_url, mc_client,
+                                     retry)
 
     return None
 


### PR DESCRIPTION
This happened when baking AP Biology on katalyst01.  Math in exercises
uses latex, which gets transformed to mathml using mathmlcloud.  The
mathml is then included in the html.  When using `etree.fromstring` to
create an element out of the mathml, sometimes `lxml.etree` raises a
`XMLSyntaxError`, e.g.:

```
  File "/home/karen/src/nebuchadnezzar/venv/lib/python3.6/site-packages/cnxepub/formatters.py", line 302, in __bytes__
    self.build()
  File "/home/karen/src/nebuchadnezzar/venv/lib/python3.6/site-packages/cnxepub/formatters.py", line 273, in build
    proc(elem)
  File "/home/karen/src/nebuchadnezzar/venv/lib/python3.6/site-packages/cnxepub/formatters.py", line 425, in _replace_exercises
    mathml = _replace_tex_math(node, mml_url, mc_client)
  File "/home/karen/src/nebuchadnezzar/venv/lib/python3.6/site-packages/cnxepub/formatters.py", line 361, in _replace_tex_math
    mml = etree.fromstring(component['source'])
  File "src/lxml/etree.pyx", line 3211, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1877, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1758, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1068, in lxml.etree._BaseParser._parseUnicodeDoc
  File "src/lxml/parser.pxi", line 601, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 711, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 640, in lxml.etree._raiseParseError
  File "<string>", line 5
lxml.etree.XMLSyntaxError: Entity 'nbsp' not defined, line 5, column 16
```

It's very hard to debug because we don't know which exercise it was.

In the future if this happens again, at least this would be logged together
with the exception:

```
Error converting math in apbio-ch37-ex003:
  math: <span data-math="20,810\ \text{kcal}/\text{m}^2/\text{yr}"></span>
  mathml: <math xmlns="http://www.w3.org/1998/Math/MathML" display="block" alttext="20 comma 810 kcal slash m squared slash yr">
  <mn>20</mn>
  <mo>,</mo>
  <mn>810</mn>
  <mtext>&nbsp;</mtext>
  <mtext>kcal</mtext>
  <mrow class="MJX-TeXAtom-ORD">
    <mo>/</mo>
  </mrow>
  <msup>
    <mtext>m</mtext>
    <mn>2</mn>
  </msup>
  <mrow class="MJX-TeXAtom-ORD">
    <mo>/</mo>
  </mrow>
  <mtext>yr</mtext>
</math>
```

making it more obvious how to fix the problem.