### PR TITLE
Better validation errors

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -480,6 +480,11 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                     .format(data_type, child.attrib.get('id'),
                             parent.metadata.get('title')))
                 raise
+            except IndexError:
+                logger.exception(
+                    'Metadata (data-type="metadata") not found:\n{}...'
+                    .format(etree.tostring(child).decode('utf-8')[:800]))
+                raise
 
             # Handle version, id and uuid from metadata
             if not metadata.get('version'):

--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -470,9 +470,16 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
 
         if data_type in ('unit', 'chapter', 'composite-chapter',
                          'page', 'composite-page'):
-            # metadata munging for all node types, in one place
-            metadata = parse_metadata(
-                    child.xpath('./*[@data-type="metadata"]')[0])
+            try:
+                # metadata munging for all node types, in one place
+                metadata = parse_metadata(
+                        child.xpath('./*[@data-type="metadata"]')[0])
+            except ValueError:
+                logger.exception(
+                    'Error when parsing metadata for {} (id: {}, parent: "{}")'
+                    .format(data_type, child.attrib.get('id'),
+                            parent.metadata.get('title')))
+                raise
 
             # Handle version, id and uuid from metadata
             if not metadata.get('version'):

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -966,3 +966,47 @@ Pointer.
         self.assertEqual(logger.exception.call_args, mock.call(
             u'Error when parsing metadata for page '
             u'(id: apple, parent: "Fruity")'))
+
+    @mock.patch('cnxepub.adapters.logger')
+    def test_missing_metadata_element(self, logger):
+        from ..adapters import adapt_single_html
+
+        page_path = os.path.join(TEST_DATA_DIR,
+                                 'collated-desserts-single-page.xhtml')
+
+        with open(page_path, 'r') as f:
+            html = f.read()
+
+        html = html.replace(
+            '<div data-type="page" id="apple">\n<div data-type="metadata">',
+            '<div data-type="page" id="apple">\n<div>')
+
+        desserts = self.assertRaises(IndexError, adapt_single_html, html)
+        self.assertEqual(logger.exception.call_args, mock.call(u"""\
+Metadata (data-type="metadata") not found:
+<div xmlns="http://www.w3.org/1999/xhtml"\
+ xmlns:bib="http://bibtexml.sf.net/"\
+ xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute"\
+ xmlns:epub="http://www.idpf.org/2007/ops"\
+ xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"\
+ xmlns:dc="http://purl.org/dc/elements/1.1/"\
+ xmlns:lrmi="http://lrmi.net/the-specification" data-type="page" id="apple">
+<div>
+      <h1 data-type="document-title" itemprop="name">Apple</h1>
+
+      <div class="authors">
+        By:
+<span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person"\
+ itemprop="author" data-type="author">
+            <a href="yum" itemprop="url" data-type="cnx-id">Good Food</a>
+          </span>
+        Edited by:
+
+        Illustrated by:
+
+        Translated by:
+
+      </div>
+
+      <div class="publishers">
+..."""))

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -947,3 +947,22 @@ Pointer.
         apple = desserts[0][0]
         self.assertIn(b'<p id="12345"><a href="/contents/chocolate">',
                       apple.content)
+
+    @mock.patch('cnxepub.adapters.logger')
+    def test_missing_required_metadata(self, logger):
+        from ..adapters import adapt_single_html
+
+        page_path = os.path.join(TEST_DATA_DIR,
+                                 'collated-desserts-single-page.xhtml')
+
+        with open(page_path, 'r') as f:
+            html = f.read()
+
+        html = html.replace(
+            '<h1 data-type="document-title" itemprop="name">Apple</h1>',
+            '<h1 data-type="document-title" itemprop="name"></h1>')
+
+        desserts = self.assertRaises(ValueError, adapt_single_html, html)
+        self.assertEqual(logger.exception.call_args, mock.call(
+            u'Error when parsing metadata for page '
+            u'(id: apple, parent: "Fruity")'))


### PR DESCRIPTION
- Better validation error when required metadata not found

  Instead of just showing the error which is the name of the metadata
  that's missing, include information about the page so we know which page
  caused this error.  For example:
  
  ```
  cnxepub ERROR Error when parsing metadata for composite-page (id: None, parent: "1 What is Physics?")
  Traceback (most recent call last):
    File "/code/venv/lib/python3.6/site-packages/cnxepub/adapters.py", line 473, in _adapt_single_html_tree
      child.xpath('./*[@data-type="metadata"]')[0])
    File "/code/venv/lib/python3.6/site-packages/cnxepub/html_parsers.py", line 74, in parse_metadata
      return parser()
    File "/code/venv/lib/python3.6/site-packages/cnxepub/html_parsers.py", line 108, in __call__
      return self.metadata
    File "/code/venv/lib/python3.6/site-packages/cnxepub/html_parsers.py", line 128, in metadata
      "A value for '{}' could not be found.".format(key))
  ValueError: A value for 'title' could not be found.
  ```

- Better validation error when metadata element not found

  It was showing just `IndexError: list index out of range` so it's hard to know
  what's wrong or where the problem is.  Now it prints out the first 800
  characters of the page (or composite-chapter in this case) so we have an idea
  of where this problem is.  For example:
  
  ```
  cnxepub ERROR Metadata (data-type="metadata") not found:
  <div xmlns="http://www.w3.org/1999/xhtml" xmlns:m="http://www.w3.org/1998/Math/MathML" class="os-eoc os-chapter-review-container" data-type="composite-chapter" data-uuid-key=".chapter-review"><h2 data-type="document-title"><span class="os-text">Chapter Review</span></h2><div class="os-eoc os-concept-container" data-type="composite-page"><h3 data-type="title"><span class="os-text">Concept Items</span></h3><div data-type="metadata" style="display: none;">
        <h1 data-type="document-title" itemprop="name">Key Equations</h1>
  
        <div class="authors">
          By:
  <span id="author-1_copy_5" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
              <a href="os_hsphysics" itemprop="url" data-type="cnx-id">os_hsphysics</a>
            </s...
  Traceback (most recent call last):
    File "/code/venv/lib/python3.6/site-packages/cnxepub/adapters.py", line 473, in _adapt_single_html_tree
      child.xpath('./*[@data-type="metadata"]')[0])
  IndexError: list index out of range
  ```
