### PR TITLE
Fix composite-page ids erroring in epub

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -494,7 +494,11 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                 elif parent.metadata.get('version') is not None:
                     metadata['version'] = parent.metadata['version']
 
-            id_ = metadata.get('cnx-archive-uri') or child.attrib.get('id')
+            uuid_key = child.get('data-uuid-key')
+            child_id = child.attrib.get('id')
+            id_ = metadata.get('cnx-archive-uri') or (child_id
+                                                      if not uuid_key
+                                                      else None)
             if not id_:
                 id_ = _compute_id(parent, child, metadata.get('title'))
                 if metadata.get('version'):

--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -237,7 +237,7 @@
 </ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_99740"></img><p id="auto_chocolate_58915">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
 <p>Click <a href="#auto_chocolate_1">here</a> to see more notes.</p>
   </div>
-<div data-type="composite-page" data-uuid-key="extra">
+<div data-type="composite-page" data-uuid-key="extra" id="a-useless-id">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
 


### PR DESCRIPTION
This should fix the errors that occur when adding ids to composite materials
during baking, meaning we can again try to link to those materials in
our PDF tables of contents. This is acheived by using the attribute
`data-uuid-key` preferentially over the `id` attribute for creating the
uuid for the new module. Now, if composite material has a
`data-uuid-key`, then it should be able to have `id` be added to it safely.

I verified this work by 1) modifying a test, adding an id to a
composite-page and ensuring it failed the test before the change in this
PR and passed after the change in this PR and 2) spinning up publishing
locally and ensuring that statistics successfully baked using a
statistics recipe built with `give-composites-ids` enabled (which was
the type of action which originally alerted us of this issue).