### PR TITLE
adds aside to the elements that get updated ids

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -105,7 +105,7 @@ class HTMLFormatter(object):
         elements = [
             'p', 'dl', 'dt', 'dd', 'table', 'div', 'section', 'figure',
             'blockquote', 'q', 'code', 'pre', 'object', 'img', 'audio',
-            'video',
+            'video', 'aside'
             ]
         elements_xpath = '|'.join(['.//{}|.//xhtml:{}'.format(elem, elem)
                                   for elem in elements])


### PR DESCRIPTION
This adds `aside` to the whitelist but I am not sure why there was a whitelist to begin with (and a randomly-generated id in the nearby code). #70 added the original code and referred to easybake also generating `auto_{}_{}` ids. 

Maybe since we have a way to build the books easily (bakery CLI) it would be a good time to see if removing the whitelist & the random-id code was ever useful.

The refs openstax/cnx-recipes#2336