### PR TITLE
generate deterministic uuids for composite pages

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -351,7 +351,10 @@ def adapt_single_html(html):
     html_root = etree.fromstring(html)
 
     metadata = parse_metadata(html_root.xpath('//*[@data-type="metadata"]')[0])
-    id_ = metadata['cnx-archive-uri'] or 'book'
+    id_ = metadata['cnx-archive-uri']
+    if id_ is None:
+        raise ValueError('Metadata element did not contain a cnx-archive-uri', 
+            etree.tostring(html_root.xpath('//*[@data-type="metadata"]')[0]))
 
     binder = Binder(id_, metadata=metadata)
     nav_tree = parse_navigation_html_to_tree(html_root, id_)
@@ -437,7 +440,7 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
             except ValueError:
                 pass
         else:  # Punt - no parent uuid, make one up for child
-            return str(uuid.uuid4())
+            raise ValueError('Could not find parent UUID while trying to generate a UUID', p_ids)
 
         uuid_key = elem.get('data-uuid-key', elem.get('class', key))
         if (sys.version_info.major == 2):  # https://bugs.python.org/issue34145

--- a/cnxepub/tests/data/desserts-single-page-bad.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-bad.xhtml
@@ -18,7 +18,7 @@
   <body xmlns:bib="http://bibtexml.sf.net/" xmlns:data="http://www.w3.org/TR/html5/dom.html#custom-data-attribute" itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
-
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="authors">
         By:
 
@@ -76,6 +76,7 @@
 <h1 data-type="document-title">Fruity</h1>
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="permissions">
         <p class="license">
           Licensed:
@@ -86,7 +87,7 @@
 <div data-type="page" id="apple">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
-
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="authors">
         By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -139,7 +140,7 @@
 <div data-type="page" id="lemon">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
-
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="authors">
         By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -195,6 +196,7 @@
 <h1 data-type="document-title">Citrus</h1>
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="permissions">
         <p class="license">
           Licensed:
@@ -205,7 +207,7 @@
 <div data-type="page" id="lemon">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
-
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="authors">
         By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -262,7 +264,7 @@
 <div data-type="page" id="chocolate">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</h1>
-
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="authors">
         By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -317,7 +319,7 @@
 <div data-type="composite-page" id="extra">
 <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
-
+      <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
       <div class="authors">
         By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">

--- a/cnxepub/tests/data/desserts-single-page-umlaut.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-umlaut.xhtml
@@ -17,6 +17,7 @@
 <body itemscope="itemscope" itemtype="http://schema.org/Book">
   <div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Dessertsäüö</h1>
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
 
     <div class="permissions">
       <p class="license">
@@ -32,6 +33,7 @@
  <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
 <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Fruityäüö</h1>
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
     <div class="permissions">
       <p class="license">
         Licensed:
@@ -41,7 +43,7 @@
 
  <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Appleäüö</h1>
-
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
     <div class="authors">
       By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -79,7 +81,7 @@
 
 </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Lemonäüö</h1>
-
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
     <div class="authors">
       By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -132,6 +134,7 @@
 
 </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Citrusäüö</h1>
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
     <span data-type="binding" data-value="translucent"/>
     <div class="authors">
       By:
@@ -157,7 +160,7 @@
 
  <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Lemon</h1>
-
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
     <div class="authors">
       By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -210,7 +213,7 @@
 
 </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">チョコレート</h1>
-
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
     <div class="authors">
       By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">
@@ -251,7 +254,7 @@
 
 </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
-
+    <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000"></span>
     <div class="authors">
       By:
 <span id="author-1" itemscope="itemscope" itemtype="http://schema.org/Person" itemprop="author" data-type="author">

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -690,7 +690,10 @@ class HTMLAdaptationTestCase(unittest.TestCase):
 
         random.seed(1)
         metadata = self.base_metadata.copy()
-        binder = Binder(metadata['title'], metadata=metadata)
+        metadata_book = self.base_metadata.copy()
+        metadata_book['cnx-archive-uri'] = '00000000-0000-0000-0000-000000000000'
+        
+        binder = Binder(metadata['title'], metadata=metadata_book)
         binder.append(Document('apple-pie', io.BytesIO(b'<body><p>Apple Pie</p></body>'),
                                metadata=metadata))
         binder.append(Document('lemon-pie', io.BytesIO(b'''\

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -277,7 +277,9 @@ class CollateTestCase(BaseModelTestCase):
         binder = self.make_binder(
             '8d75ea29',
             metadata={'version': '3', 'title': "Book One",
-                      'license_url': 'http://my.license'},
+                      'license_url': 'http://my.license',
+                      'cnx-archive-uri': 
+                            '00000000-0000-0000-0000-000000000000'},
             nodes=[
                 self.make_document(
                     id="e78d4f90",


### PR DESCRIPTION
It was pointed out that in some cases a composite page gets a different UUID every time it executes.

This may fix the problem.