### PR TITLE
Apply auto id prefixes to all elements with ids

### DIFF
--- a/cnxepub/adapters.py
+++ b/cnxepub/adapters.py
@@ -377,7 +377,8 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
 
         content = content_to_etree(page.content)
 
-        new_ids = []
+        new_ids = set()
+        suffix = 0
         for element in content.xpath('.//*[@id]'):
             id_val = element.get('id')
             if id_val.startswith('auto_'):
@@ -385,13 +386,12 @@ def _adapt_single_html_tree(parent, elem, nav_tree, top_metadata,
                 # Did content from different pages w/ same original id
                 # get moved to the same page?
                 if new_val in new_ids:
-                    suffix = 0
                     while (new_val + str(suffix)) in new_ids:
                         suffix += 1
                     new_val = new_val + str(suffix)
             else:
                 new_val = id_val
-            new_ids.append(new_val)
+            new_ids.add(new_val)
             element.set('id', new_val)
             id_map['#{}'.format(id_val)] = (page, new_val)
 

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -300,8 +300,8 @@ class SingleHTMLFormatter(object):
         self._build_binder(self.binder, self.body)
         # Fetch any includes from remote sources
         if not self.included and self.includes is not None:
-            with ThreadPoolExecutor(max_workers=self.threads) as e:
-                for match, proc in self.includes:
+            for match, proc in self.includes:
+                with ThreadPoolExecutor(max_workers=self.threads) as e:
                     for elem in self.xpath(match):
                         e.submit(proc, elem)
             self.included = True

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -9,7 +9,6 @@ from __future__ import unicode_literals
 import hashlib
 import json
 import logging
-import random
 import sys
 from io import BytesIO
 

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -109,11 +109,16 @@ class HTMLFormatter(object):
 
         def next_free_auto_id_generator():
             next_free_auto_id_generator.new_id_count = 0
+
             def inner():
-                auto_id = 'auto_{}_{}'.format(document_id, next_free_auto_id_generator.new_id_count)
+                auto_id = 'auto_{}_{}'.format(
+                    document_id,
+                    next_free_auto_id_generator.new_id_count)
                 next_free_auto_id_generator.new_id_count += 1
                 while auto_id in existing_ids:
-                    auto_id = 'auto_{}_{}'.format(document_id, next_free_auto_id_generator.new_id_count)
+                    auto_id = 'auto_{}_{}'.format(
+                        document_id,
+                        next_free_auto_id_generator.new_id_count)
                     next_free_auto_id_generator.new_id_count += 1
                 return auto_id
             return inner
@@ -138,8 +143,10 @@ class HTMLFormatter(object):
             'blockquote', 'q', 'code', 'pre', 'object', 'img', 'audio',
             'video',
         ]
-        elements_xpath = '|'.join(['.//*[local-name() = "{}"]'.format(elem, elem)
-                                   for elem in elements_need_ids])
+        elements_xpath = '|'.join([
+            './/*[local-name() = "{}"]'.format(elem, elem)
+            for elem in elements_need_ids
+        ])
 
         data_types_need_ids = [
             'equation', 'list', 'exercise', 'rule', 'example', 'note',

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -143,7 +143,7 @@ class HTMLFormatter(object):
             'video',
         ]
         elements_xpath = '|'.join([
-            './/*[local-name() = "{}"]'.format(elem, elem)
+            './/*[local-name() = "{}"]'.format(elem)
             for elem in elements_need_ids
         ])
 

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -101,48 +101,70 @@ class HTMLFormatter(object):
         """Generate unique ids for html elements in page content so that it's
         possible to link to them.
         """
-        existing_ids = content.xpath('//*/@id')
-        elements = [
+        document_id = document.id.replace('_', '')
+
+        # Step 1: prefix existing ids
+        elements_with_ids = content.xpath('//*[@id]')
+        existing_ids = set([el.attrib['id'] for el in elements_with_ids])
+
+        def next_free_auto_id_generator():
+            next_free_auto_id_generator.new_id_count = 0
+            def inner():
+                auto_id = 'auto_{}_{}'.format(document_id, next_free_auto_id_generator.new_id_count)
+                next_free_auto_id_generator.new_id_count += 1
+                while auto_id in existing_ids:
+                    auto_id = 'auto_{}_{}'.format(document_id, next_free_auto_id_generator.new_id_count)
+                    next_free_auto_id_generator.new_id_count += 1
+                return auto_id
+            return inner
+
+        next_auto_id = next_free_auto_id_generator()
+
+        old_id_to_new_id = {}
+
+        for node in elements_with_ids:
+            old_id = node.attrib['id']
+            if len(old_id) > 0:
+                new_id = 'auto_{}_{}'.format(document_id, old_id)
+            else:
+                new_id = next_auto_id()
+            node.attrib['id'] = new_id
+            old_id_to_new_id[old_id] = new_id
+            existing_ids.add(new_id)
+
+        # Step 2: give ids to elements that need them
+        elements_need_ids = [
             'p', 'dl', 'dt', 'dd', 'table', 'div', 'section', 'figure',
             'blockquote', 'q', 'code', 'pre', 'object', 'img', 'audio',
-            'video', 'aside', 'ol'
-            ]
-        elements_xpath = '|'.join(['.//{}|.//xhtml:{}'.format(elem, elem)
-                                  for elem in elements])
+            'video',
+        ]
+        elements_xpath = '|'.join(['.//*[local-name() = "{}"]'.format(elem, elem)
+                                   for elem in elements_need_ids])
 
-        data_types = [
+        data_types_need_ids = [
             'equation', 'list', 'exercise', 'rule', 'example', 'note',
             'footnote-number', 'footnote-ref', 'problem', 'solution', 'media',
             'proof', 'statement', 'commentary'
-            ]
+        ]
         data_types_xpath = '|'.join(['.//*[@data-type="{}"]'.format(data_type)
-                                     for data_type in data_types])
+                                     for data_type in data_types_need_ids])
 
         xpath = '|'.join([elements_xpath, data_types_xpath])
 
-        mapping = {}  # old id -> new id
-
         for node in content.xpath(xpath, namespaces=HTML_DOCUMENT_NAMESPACES):
-            old_id = node.attrib.get('id')
-            document_id = document.id.replace('_', '')
-            if old_id:
-                new_id = 'auto_{}_{}'.format(document_id, old_id)
-            else:
-                random_number = random.randint(0, 100000)
-                new_id = 'auto_{}_{}'.format(document_id, random_number)
-            while new_id in existing_ids:
-                random_number = random.randint(0, 100000)
-                new_id = 'auto_{}_{}'.format(document_id, random_number)
+            node_id = node.attrib.get('id')
+            if node_id:
+                continue
+            new_id = next_auto_id()
             node.attrib['id'] = new_id
-            if old_id:
-                mapping[old_id] = new_id
-            existing_ids.append(new_id)
+            existing_ids.add(new_id)
 
+        # Step 3: redirect links to elements with now prefixed ids
         for a in content.xpath('//a[@href]|//xhtml:a[@href]',
                                namespaces=HTML_DOCUMENT_NAMESPACES):
             href = a.attrib['href']
-            if href.startswith('#') and href[1:] in mapping:
-                a.attrib['href'] = '#{}'.format(mapping[href[1:]])
+            if href.startswith('#') and href[1:] in old_id_to_new_id:
+                a.attrib['href'] = '#{}'.format(old_id_to_new_id[href[1:]])
 
     @property
     def _content(self):

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -147,9 +147,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_13436">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_1">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_84744">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_0">If you finish the book, there will be cake.</p>
   
   
   </div></div><div data-type="chapter"><div data-type="metadata" style="display: none;">
@@ -216,9 +216,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_76378">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_1">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_25507">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_0">If you finish the book, there will be cake.</p>
   
   
   </div></div></div><div data-type="unit"><div data-type="metadata" style="display: none;">
@@ -295,9 +295,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_49544">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_1">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_44949">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_0">If you finish the book, there will be cake.</p>
   
   
   </div></div></div></body>

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -147,9 +147,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_17611">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_1">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_74606">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_0">If you finish the book, there will be cake.</p>
   
   
   </div></div><div data-type="chapter"><div data-type="metadata" style="display: none;">
@@ -216,9 +216,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_8271">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_1">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_33432">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_0">If you finish the book, there will be cake.</p>
   
   
   </div></div></div><div data-type="unit"><div data-type="metadata" style="display: none;">
@@ -295,9 +295,9 @@
    
     <!-- Meta elements are definitely allowed in the body of the content if they use "itemprop" -->
     
-    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_15455">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
+    <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_1">Do you understand everything in <a href="#e78d4f90-e078-49d2-beac-e95e8be70667">this page</a></p>
    
-   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_64937">If you finish the book, there will be cake.</p>
+   <p class="para" id="auto_e78d4f90-e078-49d2-beac-e95e8be70667_0">If you finish the book, there will be cake.</p>
   
   
   </div></div></div></body>

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -379,18 +379,18 @@
           data-type='exercise'
           id='auto_lemon_2'
         >
-          <div>Dehydration
+          <div>DEHYDRATION
             <img
               href='none'
-            ></img>synthesis leads to the formation of what?
+            ></img>SYNTHESIS LEADS TO THE FORMATION OF WHAT?
           </div>
           <ol
             data-number-style='lower-alpha'
           >
-            <li>monomers</li>
-            <li>polymers</li>
-            <li>carbohydrates only</li>
-            <li>water only</li>
+            <li>MONOMERS</li>
+            <li>POLYMERS</li>
+            <li>CARBOHYDRATES ONLY</li>
+            <li>WATER ONLY</li>
           </ol>
         </div>
         <div
@@ -399,7 +399,7 @@
         >
           <div
             class='missing-exercise'
-          >MISSING EXERCISE: tag:nosuchtag</div>
+          >MISSING EXERCISE: TAG:NOSUCHTAG</div>
         </div>
         <ul>
           <li>Lemon &amp; Lime Crush,</li>
@@ -589,18 +589,18 @@
             data-type='exercise'
             id='auto_lemon_2'
           >
-            <div>Dehydration
+            <div>DEHYDRATION
               <img
                 href='none'
-              ></img>synthesis leads to the formation of what?
+              ></img>SYNTHESIS LEADS TO THE FORMATION OF WHAT?
             </div>
             <ol
               data-number-style='lower-alpha'
             >
-              <li>monomers</li>
-              <li>polymers</li>
-              <li>carbohydrates only</li>
-              <li>water only</li>
+              <li>MONOMERS</li>
+              <li>POLYMERS</li>
+              <li>CARBOHYDRATES ONLY</li>
+              <li>WATER ONLY</li>
             </ol>
           </div>
           <div
@@ -609,7 +609,7 @@
           >
             <div
               class='missing-exercise'
-            >MISSING EXERCISE: tag:nosuchtag</div>
+            >MISSING EXERCISE: TAG:NOSUCHTAG</div>
           </div>
           <ul>
             <li>Lemon &amp; Lime Crush,</li>

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -261,7 +261,7 @@
         </div>
         <h1>Apple Desserts</h1>
         <p
-          id='auto_apple_0'
+          id='auto_apple_2'
         >
           <a
             href='#lemon'
@@ -269,11 +269,11 @@
         </p>
         <ul>
           <li
-            id='auto_apple_auto_apple_13436'
+            id='auto_apple_auto_apple_1'
           >Apple Crumble,</li>
           <li>Apfelstrudel,</li>
           <li
-            id='auto_apple_auto_apple_17611'
+            id='auto_apple_auto_apple_0'
           >Caramel Apple,</li>
           <li>Apple Pie,</li>
           <li>Apple sauce...</li>

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -261,7 +261,7 @@
         </div>
         <h1>Apple Desserts</h1>
         <p
-          id='auto_apple_84744'
+          id='auto_apple_0'
         >
           <a
             href='#lemon'
@@ -269,11 +269,11 @@
         </p>
         <ul>
           <li
-            id='auto_apple_13436'
+            id='auto_apple_auto_apple_13436'
           >Apple Crumble,</li>
           <li>Apfelstrudel,</li>
           <li
-            id='auto_apple_17611'
+            id='auto_apple_auto_apple_17611'
           >Caramel Apple,</li>
           <li>Apple Pie,</li>
           <li>Apple sauce...</li>
@@ -368,16 +368,16 @@
         </div>
         <h1>Lemon Desserts</h1>
         <p
-          id='auto_lemon_76378'
+          id='auto_lemon_0'
         >Yum!
           <img
-            id='auto_lemon_25507'
+            id='auto_lemon_1'
             src='/resources/1x1.jpg'
           ></img>
         </p>
         <div
           data-type='exercise'
-          id='auto_lemon_49544'
+          id='auto_lemon_2'
         >
           <div>Dehydration
             <img
@@ -395,7 +395,7 @@
         </div>
         <div
           data-type='exercise'
-          id='auto_lemon_44949'
+          id='auto_lemon_3'
         >
           <div
             class='missing-exercise'
@@ -578,16 +578,16 @@
           </div>
           <h1>Lemon Desserts</h1>
           <p
-            id='auto_lemon_78873'
+            id='auto_lemon_0'
           >Yum!
             <img
-              id='auto_lemon_9386'
+              id='auto_lemon_1'
               src='/resources/1x1.jpg'
             ></img>
           </p>
           <div
             data-type='exercise'
-            id='auto_lemon_2834'
+            id='auto_lemon_2'
           >
             <div>Dehydration
               <img
@@ -605,7 +605,7 @@
           </div>
           <div
             data-type='exercise'
-            id='auto_lemon_83577'
+            id='auto_lemon_3'
           >
             <div
               class='missing-exercise'
@@ -708,7 +708,7 @@
       </div>
       <h1>Chocolate Desserts</h1>
       <p
-        id='auto_chocolate_76228'
+        id='auto_chocolate_0'
       >
         <a
           href='#auto_chocolate_list'
@@ -726,11 +726,11 @@
         </ul>
       </div>
       <img
-        id='auto_chocolate_210'
+        id='auto_chocolate_1'
         src='/resources/1x1.jpg'
       ></img>
       <p
-        id='auto_chocolate_44539'
+        id='auto_chocolate_2'
       >チョコレートデザート</p>
     </div>
     <div
@@ -810,10 +810,10 @@
       </div>
       <h1>Extra Stuff</h1>
       <p
-        id='auto_extra_72154'
+        id='auto_extra_0'
       >This is a composite page.</p>
       <p
-        id='auto_extra_22876'
+        id='auto_extra_1'
       >Here is a
         <a
           href='#auto_chocolate_list'

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -262,7 +262,7 @@
         </div>
         <h1>Apple Desserts</h1>
         <p
-          id='auto_apple_0'
+          id='auto_apple_2'
         >
           <a
             href='#lemon'
@@ -270,11 +270,11 @@
         </p>
         <ul>
           <li
-            id='auto_apple_auto_apple_13436'
+            id='auto_apple_auto_apple_1'
           >Apple Crumble,</li>
           <li>Apfelstrudel,</li>
           <li
-            id='auto_apple_auto_apple_17611'
+            id='auto_apple_auto_apple_0'
           >Caramel Apple,</li>
           <li>Apple Pie,</li>
           <li>Apple sauce...</li>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -262,7 +262,7 @@
         </div>
         <h1>Apple Desserts</h1>
         <p
-          id='auto_apple_84744'
+          id='auto_apple_0'
         >
           <a
             href='#lemon'
@@ -270,11 +270,11 @@
         </p>
         <ul>
           <li
-            id='auto_apple_13436'
+            id='auto_apple_auto_apple_13436'
           >Apple Crumble,</li>
           <li>Apfelstrudel,</li>
           <li
-            id='auto_apple_17611'
+            id='auto_apple_auto_apple_17611'
           >Caramel Apple,</li>
           <li>Apple Pie,</li>
           <li>Apple sauce...</li>
@@ -369,23 +369,21 @@
         </div>
         <h1>Lemon Desserts</h1>
         <p
-          id='auto_lemon_76378'
+          id='auto_lemon_0'
         >Yum!
           <img
-            id='auto_lemon_25507'
+            id='auto_lemon_1'
             src='/resources/1x1.jpg'
           ></img>
         </p>
         <div
           data-type='exercise'
-          id='auto_lemon_49544'
+          id='auto_lemon_2'
         >
           <div
-            class="exercise-stimulus"
+            class='exercise-stimulus'
           >
-            <p>
-              Please answer the following question:
-            </p>
+            <p>Please answer the following question:</p>
           </div>
           <div>Dehydration
             <img
@@ -442,7 +440,7 @@
         </div>
         <div
           data-type='exercise'
-          id='auto_lemon_44949'
+          id='auto_lemon_3'
         >
           <div
             class='missing-exercise'
@@ -625,23 +623,21 @@
           </div>
           <h1>Lemon Desserts</h1>
           <p
-            id='auto_lemon_78873'
+            id='auto_lemon_0'
           >Yum!
             <img
-              id='auto_lemon_9386'
+              id='auto_lemon_1'
               src='/resources/1x1.jpg'
             ></img>
           </p>
           <div
             data-type='exercise'
-            id='auto_lemon_2834'
+            id='auto_lemon_2'
           >
             <div
-              class="exercise-stimulus"
+              class='exercise-stimulus'
             >
-              <p>
-                Please answer the following question:
-              </p>
+              <p>Please answer the following question:</p>
             </div>
             <div>Dehydration
               <img
@@ -698,7 +694,7 @@
           </div>
           <div
             data-type='exercise'
-            id='auto_lemon_83577'
+            id='auto_lemon_3'
           >
             <div
               class='missing-exercise'
@@ -801,7 +797,7 @@
       </div>
       <h1>Chocolate Desserts</h1>
       <p
-        id='auto_chocolate_76228'
+        id='auto_chocolate_0'
       >
         <a
           href='#auto_chocolate_list'
@@ -819,11 +815,11 @@
         </ul>
       </div>
       <img
-        id='auto_chocolate_210'
+        id='auto_chocolate_1'
         src='/resources/1x1.jpg'
       ></img>
       <p
-        id='auto_chocolate_44539'
+        id='auto_chocolate_2'
       >チョコレートデザート</p>
     </div>
     <div
@@ -903,10 +899,10 @@
       </div>
       <h1>Extra Stuff</h1>
       <p
-        id='auto_extra_72154'
+        id='auto_extra_0'
       >This is a composite page.</p>
       <p
-        id='auto_extra_22876'
+        id='auto_extra_1'
       >Here is a
         <a
           href='#auto_chocolate_list'

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -383,36 +383,36 @@
           <div
             class='exercise-stimulus'
           >
-            <p>Please answer the following question:</p>
+            <p>PLEASE ANSWER THE FOLLOWING QUESTION:</p>
           </div>
-          <div>Dehydration
+          <div>DEHYDRATION
             <img
               href='none'
-            ></img>synthesis leads to the formation of what?
+            ></img>SYNTHESIS LEADS TO THE FORMATION OF WHAT?
           </div>
           <ol
             data-number-style='lower-alpha'
           >
             <li
               data-correctness='0.0'
-            >monomers</li>
+            >MONOMERS</li>
             <li
               data-correctness='1.0'
-            >polymers (
+            >POLYMERS (
               <span
                 data-math='retry'
               ></span>)
             </li>
             <li
               data-correctness='0.0'
-            >carbohydrates only (
+            >CARBOHYDRATES ONLY (
               <span
                 data-math=''
               ></span>)
             </li>
             <li
               data-correctness='0.0'
-            >water only (
+            >WATER ONLY (
               <m:math
                 display='inline'
               >
@@ -425,7 +425,7 @@
             </li>
             <li
               data-correctness='1.0'
-            >polymer and water (
+            >POLYMER AND WATER (
               <m:math
                 display='block'
               >
@@ -444,7 +444,7 @@
         >
           <div
             class='missing-exercise'
-          >MISSING EXERCISE: tag:nosuchtag</div>
+          >MISSING EXERCISE: TAG:NOSUCHTAG</div>
         </div>
         <ul>
           <li>Lemon &amp; Lime Crush,</li>
@@ -637,36 +637,36 @@
             <div
               class='exercise-stimulus'
             >
-              <p>Please answer the following question:</p>
+              <p>PLEASE ANSWER THE FOLLOWING QUESTION:</p>
             </div>
-            <div>Dehydration
+            <div>DEHYDRATION
               <img
                 href='none'
-              ></img>synthesis leads to the formation of what?
+              ></img>SYNTHESIS LEADS TO THE FORMATION OF WHAT?
             </div>
             <ol
               data-number-style='lower-alpha'
             >
               <li
                 data-correctness='0.0'
-              >monomers</li>
+              >MONOMERS</li>
               <li
                 data-correctness='1.0'
-              >polymers (
+              >POLYMERS (
                 <span
                   data-math='retry'
                 ></span>)
               </li>
               <li
                 data-correctness='0.0'
-              >carbohydrates only (
+              >CARBOHYDRATES ONLY (
                 <span
                   data-math=''
                 ></span>)
               </li>
               <li
                 data-correctness='0.0'
-              >water only (
+              >WATER ONLY (
                 <m:math
                   display='inline'
                 >
@@ -679,7 +679,7 @@
               </li>
               <li
                 data-correctness='1.0'
-              >polymer and water (
+              >POLYMER AND WATER (
                 <m:math
                   display='block'
                 >
@@ -698,7 +698,7 @@
           >
             <div
               class='missing-exercise'
-            >MISSING EXERCISE: tag:nosuchtag</div>
+            >MISSING EXERCISE: TAG:NOSUCHTAG</div>
           </div>
           <ul>
             <li>Lemon &amp; Lime Crush,</li>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_0"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
+<p id="auto_apple_2"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_1">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_0">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -115,20 +115,20 @@
 <p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
 <div data-type="exercise" id="auto_lemon_2">
-    <div class="exercise-stimulus"><p>Please answer the following question:</p></div>
-        <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
+    <div class="exercise-stimulus"><p>PLEASE ANSWER THE FOLLOWING QUESTION:</p></div>
+        <div>DEHYDRATION <img href="none"/> SYNTHESIS LEADS TO THE FORMATION OF WHAT?</div>
             <ol data-number-style="lower-alpha">
-                    <li data-correctness="0.0">monomers</li>
-                    <li data-correctness="1.0">polymers (<span data-math="retry"/>)</li>
-                    <li data-correctness="0.0">carbohydrates only (<span data-math=""/>)</li>
-                    <li data-correctness="0.0">water only (<m:math display="inline">
+                    <li data-correctness="0.0">MONOMERS</li>
+                    <li data-correctness="1.0">POLYMERS (<span data-math="retry"/>)</li>
+                    <li data-correctness="0.0">CARBOHYDRATES ONLY (<span data-math=""/>)</li>
+                    <li data-correctness="0.0">WATER ONLY (<m:math display="inline">
   <m:msub>
     <m:mtext>H</m:mtext>
     <m:mn>2</m:mn>
   </m:msub>
   <m:mtext>O</m:mtext>
 </m:math>)</li>
-                    <li data-correctness="1.0">polymer and water (<m:math display="block">
+                    <li data-correctness="1.0">POLYMER AND WATER (<m:math display="block">
   <m:msub>
     <m:mtext>H</m:mtext>
     <m:mn>2</m:mn>
@@ -141,7 +141,7 @@
 
 
 <div data-type="exercise" id="auto_lemon_3">
-    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
+    <div class="missing-exercise">MISSING EXERCISE: TAG:NOSUCHTAG</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -210,20 +210,20 @@
 <p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
 <div data-type="exercise" id="auto_lemon_2">
-    <div class="exercise-stimulus"><p>Please answer the following question:</p></div>
-        <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
+    <div class="exercise-stimulus"><p>PLEASE ANSWER THE FOLLOWING QUESTION:</p></div>
+        <div>DEHYDRATION <img href="none"/> SYNTHESIS LEADS TO THE FORMATION OF WHAT?</div>
             <ol data-number-style="lower-alpha">
-                    <li data-correctness="0.0">monomers</li>
-                    <li data-correctness="1.0">polymers (<span data-math="retry"/>)</li>
-                    <li data-correctness="0.0">carbohydrates only (<span data-math=""/>)</li>
-                    <li data-correctness="0.0">water only (<m:math display="inline">
+                    <li data-correctness="0.0">MONOMERS</li>
+                    <li data-correctness="1.0">POLYMERS (<span data-math="retry"/>)</li>
+                    <li data-correctness="0.0">CARBOHYDRATES ONLY (<span data-math=""/>)</li>
+                    <li data-correctness="0.0">WATER ONLY (<m:math display="inline">
   <m:msub>
     <m:mtext>H</m:mtext>
     <m:mn>2</m:mn>
   </m:msub>
   <m:mtext>O</m:mtext>
 </m:math>)</li>
-                    <li data-correctness="1.0">polymer and water (<m:math display="block">
+                    <li data-correctness="1.0">POLYMER AND WATER (<m:math display="block">
   <m:msub>
     <m:mtext>H</m:mtext>
     <m:mn>2</m:mn>
@@ -236,7 +236,7 @@
 
 
 <div data-type="exercise" id="auto_lemon_3">
-    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
+    <div class="missing-exercise">MISSING EXERCISE: TAG:NOSUCHTAG</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_74606"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
+<p id="auto_apple_0"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
@@ -112,9 +112,9 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_8271">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_33432"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_15455">
+<div data-type="exercise" id="auto_lemon_2">
     <div class="exercise-stimulus"><p>Please answer the following question:</p></div>
         <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
             <ol data-number-style="lower-alpha">
@@ -140,7 +140,7 @@
 
 
 
-<div data-type="exercise" id="auto_lemon_64937">
+<div data-type="exercise" id="auto_lemon_3">
     <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
@@ -207,9 +207,9 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_58915">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_61898"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_85405">
+<div data-type="exercise" id="auto_lemon_2">
     <div class="exercise-stimulus"><p>Please answer the following question:</p></div>
         <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
             <ol data-number-style="lower-alpha">
@@ -235,7 +235,7 @@
 
 
 
-<div data-type="exercise" id="auto_lemon_49756">
+<div data-type="exercise" id="auto_lemon_3">
     <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
@@ -277,13 +277,13 @@
    
 <h1>Chocolate Desserts</h1>
 
-<p id="auto_chocolate_12302"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
+<p id="auto_chocolate_0"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_63944"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_1"/><p id="auto_chocolate_2">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -314,9 +314,9 @@
    
 <h1>Extra Stuff</h1>
 
-<p id="auto_extra_51093">This is a composite page.</p>
+<p id="auto_extra_0">This is a composite page.</p>
 
-<p id="auto_extra_56723">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
+<p id="auto_extra_1">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
 
 
   </div></body>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_0"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
+<p id="auto_apple_2"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_1">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_0">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_74606"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
+<p id="auto_apple_0"><a href="#lemon">LINK TO LEMON</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
@@ -112,9 +112,9 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_8271">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_33432"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_15455">
+<div data-type="exercise" id="auto_lemon_2">
     <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
             <ol data-number-style="lower-alpha">
                     <li>monomers</li>
@@ -126,7 +126,7 @@
 
 
 
-<div data-type="exercise" id="auto_lemon_64937">
+<div data-type="exercise" id="auto_lemon_3">
     <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
@@ -193,10 +193,10 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_58915">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_61898"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_85405">
-    <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
+<div data-type="exercise" id="auto_lemon_2">
+    <div>DEHYDRATION <img href="none"/> SYNTHESIS LEADS TO THE FORMATION OF WHAT?</div>
             <ol data-number-style="lower-alpha">
                     <li>monomers</li>
                     <li>polymers</li>
@@ -207,8 +207,8 @@
 
 
 
-<div data-type="exercise" id="auto_lemon_49756">
-    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
+<div data-type="exercise" id="auto_lemon_3">
+    <div class="missing-exercise">MISSING EXERCISE: TAG:NOSUCHTAG</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -249,13 +249,13 @@
    
 <h1>Chocolate Desserts</h1>
 
-<p id="auto_chocolate_12302"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
+<p id="auto_chocolate_0"><a href="#auto_chocolate_list">LIST</a> of desserts to try:</p>
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_63944"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_1"/><p id="auto_chocolate_2">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -286,9 +286,9 @@
    
 <h1>Extra Stuff</h1>
 
-<p id="auto_extra_51093">This is a composite page.</p>
+<p id="auto_extra_0">This is a composite page.</p>
 
-<p id="auto_extra_56723">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
+<p id="auto_extra_1">Here is a <a href="#auto_chocolate_list">LINK</a> to another document.</p>
 
 
   </div></body>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -115,19 +115,19 @@
 <p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
 <div data-type="exercise" id="auto_lemon_2">
-    <div>Dehydration <img href="none"/> synthesis leads to the formation of what?</div>
+    <div>DEHYDRATION <img href="none"/> SYNTHESIS LEADS TO THE FORMATION OF WHAT?</div>
             <ol data-number-style="lower-alpha">
-                    <li>monomers</li>
-                    <li>polymers</li>
-                    <li>carbohydrates only</li>
-                    <li>water only</li>
+                    <li>MONOMERS</li>
+                    <li>POLYMERS</li>
+                    <li>CARBOHYDRATES ONLY</li>
+                    <li>WATER ONLY</li>
             </ol>
 </div>
 
 
 
 <div data-type="exercise" id="auto_lemon_3">
-    <div class="missing-exercise">MISSING EXERCISE: tag:nosuchtag</div></div>
+    <div class="missing-exercise">MISSING EXERCISE: TAG:NOSUCHTAG</div></div>
 
 <ul><li>Lemon &amp; Lime Crush,</li>
     <li>Lemon Drizzle Loaf,</li>
@@ -198,10 +198,10 @@
 <div data-type="exercise" id="auto_lemon_2">
     <div>DEHYDRATION <img href="none"/> SYNTHESIS LEADS TO THE FORMATION OF WHAT?</div>
             <ol data-number-style="lower-alpha">
-                    <li>monomers</li>
-                    <li>polymers</li>
-                    <li>carbohydrates only</li>
-                    <li>water only</li>
+                    <li>MONOMERS</li>
+                    <li>POLYMERS</li>
+                    <li>CARBOHYDRATES ONLY</li>
+                    <li>WATER ONLY</li>
             </ol>
 </div>
 

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_0"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
+<p id="auto_apple_2"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_1">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_0">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_84744"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
+<p id="auto_apple_0"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
@@ -112,16 +112,16 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_76378">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_25507"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_49544">
+<div data-type="exercise" id="auto_lemon_2">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
 </div>
 
 
 
-<div data-type="exercise" id="auto_lemon_44949">
-    <p id="auto_lemon_65159">
+<div data-type="exercise" id="auto_lemon_3">
+    <p id="auto_lemon_4">
     <a href="#ost/api/ex/nosuchtag">[link]</a>
     </p>
 </div>
@@ -190,16 +190,16 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_78873">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_9386"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_2834">
+<div data-type="exercise" id="auto_lemon_2">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
 </div>
 
 
 
-<div data-type="exercise" id="auto_lemon_83577">
-    <p id="auto_lemon_43277">
+<div data-type="exercise" id="auto_lemon_3">
+    <p id="auto_lemon_4">
     <a href="#ost/api/ex/nosuchtag">[link]</a>
     </p>
 </div>
@@ -243,13 +243,13 @@
    
 <h1>Chocolate Desserts</h1>
 
-<p id="auto_chocolate_76228"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
+<p id="auto_chocolate_0"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_210"/><p id="auto_chocolate_44539">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_1"/><p id="auto_chocolate_2">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -280,9 +280,9 @@
    
 <h1>Extra Stuff</h1>
 
-<p id="auto_extra_72154">This is a composite page.</p>
+<p id="auto_extra_0">This is a composite page.</p>
 
-<p id="auto_extra_22876">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+<p id="auto_extra_1">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
 
 
   </div></body>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_74606"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
+<p id="auto_apple_0"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>
@@ -112,16 +112,16 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_8271">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_33432"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_15455">
+<div data-type="exercise" id="auto_lemon_2">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
 </div>
 
 
 
-<div data-type="exercise" id="auto_lemon_64937">
-    <p id="auto_lemon_99740">
+<div data-type="exercise" id="auto_lemon_3">
+    <p id="auto_lemon_4">
     <a href="#ost/api/ex/nosuchtag">[link]</a>
     </p>
 </div>
@@ -190,16 +190,16 @@
    
 <h1>Lemon Desserts</h1>
 
-<p id="auto_lemon_58915">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_61898"/></p>
+<p id="auto_lemon_0">Yum! <img src="/resources/1x1.jpg" id="auto_lemon_1"/></p>
 
-<div data-type="exercise" id="auto_lemon_85405">
+<div data-type="exercise" id="auto_lemon_2">
     <a href="#ost/api/ex/apbio-ch03-ex002">[link]</a>
 </div>
 
 
 
-<div data-type="exercise" id="auto_lemon_49756">
-    <p id="auto_lemon_27519">
+<div data-type="exercise" id="auto_lemon_3">
+    <p id="auto_lemon_4">
     <a href="#ost/api/ex/nosuchtag">[link]</a>
     </p>
 </div>
@@ -243,13 +243,13 @@
    
 <h1>Chocolate Desserts</h1>
 
-<p id="auto_chocolate_12302"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
+<p id="auto_chocolate_0"><a href="#auto_chocolate_list">List</a> of desserts to try:</p>
 
 <div data-type="list" id="auto_chocolate_list"><ul><li>Chocolate Orange Tart,</li>
     <li>Hot Mocha Puddings,</li>
     <li>Chocolate and Banana French Toast,</li>
     <li>Chocolate Truffles...</li>
-</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_63944"/><p id="auto_chocolate_3715">チョコレートデザート</p>
+</ul></div><img src="/resources/1x1.jpg" id="auto_chocolate_1"/><p id="auto_chocolate_2">チョコレートデザート</p>
 
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
@@ -280,9 +280,9 @@
    
 <h1>Extra Stuff</h1>
 
-<p id="auto_extra_51093">This is a composite page.</p>
+<p id="auto_extra_0">This is a composite page.</p>
 
-<p id="auto_extra_56723">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
+<p id="auto_extra_1">Here is a <a href="#auto_chocolate_list">link</a> to another document.</p>
 
 
   </div></body>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -70,11 +70,11 @@
    
 <h1>Apple Desserts</h1>
 
-<p id="auto_apple_0"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
+<p id="auto_apple_2"><a href="#lemon">Link to lemon</a>. Here are some examples:</p>
 
-<ul><li id="auto_apple_auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_auto_apple_1">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_auto_apple_0">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>

--- a/cnxepub/tests/scripts/test_single_html.py
+++ b/cnxepub/tests/scripts/test_single_html.py
@@ -74,9 +74,6 @@ class SingleHTMLTestCase(unittest.TestCase):
             self.xpath('xhtml:head/xhtml:script/@src'))
 
     def test_w_html_out(self):
-        import random
-        random.seed(1)
-
         html_path = os.path.join(
             TEST_DATA_DIR, 'book-single-page-actual.xhtml')
         if not IS_PY3:

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -688,7 +688,6 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         from ..formatters import SingleHTMLFormatter
         from ..models import Binder, Document, DocumentPointer
 
-        random.seed(1)
         metadata = self.base_metadata.copy()
         binder = Binder(metadata['title'], metadata=metadata)
         binder.append(Document('apple-pie', io.BytesIO(b'<body><p>Apple Pie</p></body>'),
@@ -701,6 +700,8 @@ class HTMLAdaptationTestCase(unittest.TestCase):
     <body>
         <h1>Lemon Pie</h1>
         <p>Yum.</p>
+        <p id="dupe">Yum.</p>
+        <p id="dupe">Yum.</p>
     </body>
 </html>'''), metadata=metadata))
         binder.append(DocumentPointer('content-ident-hash', metadata={
@@ -710,15 +711,16 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         single_html = str(SingleHTMLFormatter(binder))
         adapted_binder = adapt_single_html(single_html)
 
-        random.seed(1)
         self.assertEqual(len(adapted_binder), len(binder))
         self.assertEqual(adapted_binder[0].id, 'apple-pie')
         self.assertEqual(adapted_binder[1].id, 'lemon-pie')
         self.assertEqual(adapted_binder[0].content.decode('utf-8'), '''\
 <body xmlns="http://www.w3.org/1999/xhtml"><div data-type="page" id="apple-pie"><p id="{}">Apple Pie</p>
-  </div></body>'''.format(random.randint(0, 100000)))
+  </div></body>'''.format(0))
         self.assertEqual(adapted_binder[1].content.decode('utf-8'), '''\
-<body xmlns="http://www.w3.org/1999/xhtml"><div data-type="page" id="lemon-pie"><h1>Lemon Pie</h1>\n        \n        <p id="{}">Yum.</p>\n    \n    \n  </div></body>'''.format(random.randint(0, 100000)))
+<body xmlns="http://www.w3.org/1999/xhtml"><div data-type="page" id="lemon-pie">\
+<h1>Lemon Pie</h1>\n        \n        <p id="0">Yum.</p>\n        \n        <p id="dupe">Yum.</p>\n        \n        <p id="dupe0">Yum.</p>\n    \n    \n  \
+</div></body>'''.format(0, 0))
         self.assertEqual(adapted_binder[2].id, 'content-ident-hash')
         self.assertEqual(adapted_binder[2].metadata['title'],
                          'Test Document Pointer')
@@ -807,7 +809,7 @@ Pointer.
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, apple_metadata)
-        self.assertIn(b'<p id="74606">'
+        self.assertIn(b'<p id="0">'
                       b'<a href="/contents/lemon">Link to lemon</a>. '
                       b'Here are some examples:</p>',
                       apple.content)
@@ -823,8 +825,8 @@ Pointer.
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, lemon_metadata)
-        self.assertIn(b'<p id="8271">Yum! <img src="/resources/1x1.jpg" '
-                      b'id="33432"/></p>', lemon.content)
+        self.assertIn(b'<p id="0">Yum! <img src="/resources/1x1.jpg" '
+                      b'id="1"/></p>', lemon.content)
         self.assertEqual(u'<span>1.1</span> <span>|</span> <span>'
                          u'レモン</span>',
                          fruity.get_title_for_node(lemon))
@@ -848,7 +850,7 @@ Pointer.
         metadata['title'] = u'チョコレート'
         metadata['version'] = '1.3'
         self.assertEqual(metadata, chocolate_metadata)
-        self.assertIn(b'<p id="12302"><a href="#list">List</a> of',
+        self.assertIn(b'<p id="0"><a href="#list">List</a> of',
                       chocolate.content)
         self.assertIn(b'<div data-type="list" id="list"><ul>',
                       chocolate.content)
@@ -865,7 +867,7 @@ Pointer.
         metadata['title'] = 'Extra Stuff'
         metadata['version'] = '1.3'
         self.assertEqual(metadata, extra_metadata)
-        self.assertIn(b'<p id="56723">Here is a <a href="/contents/chocolate'
+        self.assertIn(b'<p id="1">Here is a <a href="/contents/chocolate'
                       b'#list">link</a> to another document.</p>',
                       extra.content)
         self.assertEqual('Extra Stuff', desserts.get_title_for_node(extra))

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -809,7 +809,7 @@ Pointer.
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
         self.assertEqual('summary', summary.text)
         self.assertEqual(metadata, apple_metadata)
-        self.assertIn(b'<p id="0">'
+        self.assertIn(b'<p id="2">'
                       b'<a href="/contents/lemon">Link to lemon</a>. '
                       b'Here are some examples:</p>',
                       apple.content)

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -697,9 +697,9 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
 <body>
 <h1>Apple Desserts</h1>
 <p><a href="/contents/lemon">Link to lemon</a>. Here are some examples:</p>
-<ul><li id="auto_apple_13436">Apple Crumble,</li>
+<ul><li id="auto_apple_1">Apple Crumble,</li>
     <li>Apfelstrudel,</li>
-    <li id="auto_apple_17611">Caramel Apple,</li>
+    <li id="auto_apple_0">Caramel Apple,</li>
     <li>Apple Pie,</li>
     <li>Apple sauce...</li>
 </ul>

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -843,6 +843,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         includes = [exercise_callback_factory(exercise_match,
                                               exercise_url,
                                               mc_client),
+                    ('//xhtml:*[@data-type = "exercise"]', _upcase_text),
                     ('//xhtml:a', _upcase_text)]
 
         actual = SingleHTMLFormatter(self.desserts,
@@ -899,6 +900,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
                                               mc_client,
                                               exercise_token,
                                               mathml_url),
+                    ('//xhtml:*[@data-type = "exercise"]', _upcase_text),
                     ('//xhtml:a', _upcase_text)]
 
         actual = SingleHTMLFormatter(self.desserts,

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -621,12 +621,9 @@ class HTMLFormatterTestCase(unittest.TestCase):
         self.assertEqual(u'entrée', lis[0][0].text)
 
     def test_document_auto_generate_ids(self):
-        import random
-
         from ..models import Document
         from ..formatters import HTMLFormatter
 
-        random.seed(1)
         content = """<body>\
 <div class="title" id="title">Preface</div>
 <p class="para" id="my-id">This thing and <em>that</em> thing.</p>
@@ -639,9 +636,8 @@ class HTMLFormatterTestCase(unittest.TestCase):
 <p class="para" id="auto_{id}_my-id">This thing and <em>that</em> thing.</p>
 
 <p class="para" id="auto_{id}_{n}"><a href="#auto_{id}_title">Link</a> to title</p>\
-""".format(id=page_one_id, n=random.randint(0, 100000))
+""".format(id=page_one_id, n=0)
 
-        random.seed(1)
         document = Document(page_one_id, content)
         formatted = str(HTMLFormatter(document, generate_ids=True))
         self.assertIn(expected_content, formatted)
@@ -780,11 +776,8 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
             resources=[cover_png])
 
     def test_binder(self):
-        import random
-
         from ..formatters import SingleHTMLFormatter
 
-        random.seed(1)
         page_path = os.path.join(TEST_DATA_DIR, 'desserts-single-page.xhtml')
         if not IS_PY3:
             page_path = page_path.replace('.xhtml', '-py2.xhtml')
@@ -805,36 +798,32 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
         os.remove(out_path)
 
     def test_str_unicode_bytes(self):
-        import random
-
         from ..formatters import SingleHTMLFormatter
 
-        random.seed(1)
         html = bytes(SingleHTMLFormatter(self.desserts))
         if IS_PY3:
-            random.seed(1)
             self.assertMultiLineEqual(
                 html.decode('utf-8'), str(SingleHTMLFormatter(self.desserts)))
         else:
-            random.seed(1)
             self.assertMultiLineEqual(
                 html, str(SingleHTMLFormatter(self.desserts)))
-            random.seed(1)
             self.assertMultiLineEqual(
                 html,
                 unicode(SingleHTMLFormatter(self.desserts)).encode('utf-8'))
 
     @mock.patch('requests.get', mocked_requests_get)
     def test_includes_callback(self):
-        import random
-
         from ..formatters import SingleHTMLFormatter
 
         def _upcase_text(elem):
             if elem.text:
                 elem.text = elem.text.upper()
+            for child in elem.iterdescendants():
+                if child.text:
+                    child.text = child.text.upper()
+                if child.tail:
+                    child.tail = child.tail.upper()
 
-        random.seed(1)
         page_path = os.path.join(TEST_DATA_DIR, 'desserts-includes.xhtml')
         if not IS_PY3:
             page_path = page_path.replace('.xhtml', '-py2.xhtml')
@@ -877,15 +866,17 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
     @mock.patch('requests.post', mocked_requests_post)
     @mock.patch('requests.get', mocked_requests_get)
     def test_includes_token_callback(self):
-        import random
-
         from ..formatters import SingleHTMLFormatter
 
         def _upcase_text(elem):
             if elem.text:
                 elem.text = elem.text.upper()
+            for child in elem.iterdescendants():
+                if child.text:
+                    child.text = child.text.upper()
+                if child.tail:
+                    child.tail = child.tail.upper()
 
-        random.seed(1)
         page_path = os.path.join(TEST_DATA_DIR, 'desserts-includes-token.xhtml')
         if not IS_PY3:
             page_path = page_path.replace('.xhtml', '-py2.xhtml')


### PR DESCRIPTION
Hopefully this should take care of our duplicate id issues for good, at least with respect to cnx-epub.
### In This PR:
- Still only applies **new** IDs to elements in the hard coded list, but now also applies prefixing to **all** elements with existing IDs, not just those in the list
- Uses some sets instead of lists for checking id existence for o(logn) checks over o(n) checks
- Removes randomness from auto id generation and just start counting up from zero to determine auto id suffixes. This should help us make book builds more deterministic as well
- Added onto `test_from_formatter_to_adapter` (See: https://github.com/openstax/cnx-epub/pull/167/files#diff-38406bf6e5b6bc25a346d89b5c4d6199R703) to check that modules with duplicate IDs that get thrown into the `adapt_single_html` function are not duplicated afterwards.
- Adjusts regression tests to match and removes seeded randoms from the tests, since they are no longer needed (and made one or two tweaks to utility functions)
- Partially resolves a race condition that existed with `SingleHTMLFormatter->includes` in order to get tests to pass consistently

### One regression that I ignored, but I want to discuss:
Elements that were not already on the list of elements to prefix, but now receive prefixing which also already started with `auto_` are given a second `auto_` prefix. The regression test perhaps suggests this is something that should occur. See: https://github.com/openstax/cnx-epub/pull/167/files#diff-93849c0776f90f81b2d971f5cb915dfeR272 (`auto_apple_auto_apple`). Should we add a special case to not prefix ids that already begin with `auto_` to avoid this?