### PR TITLE
Add / augment metadata fields

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -619,6 +619,14 @@ HTML_DOCUMENT = """\
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">{{ \
               metadata['title'] }}</h1>
+      {% if metadata.get('revised') %}
+      <span data-type="revised" data-value="{{ \
+          metadata['revised'] }}" />
+      {% endif %}
+      {% if metadata.get('canonical_book_uuid') %}
+      <span data-type="canonical-book-uuid" data-value="{{ \
+          metadata['canonical_book_uuid'] }}" />
+      {% endif %}
       {% if is_translucent %}
       <span data-type="binding" data-value="translucent" />
       {%- endif %}

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -97,7 +97,7 @@ class DocumentMetadataParser:
         'license_text', 'editors', 'illustrators', 'translators',
         'publishers', 'copyright_holders', 'authors', 'summary',
         'cnx-archive-uri', 'cnx-archive-shortid', 'derived_from_uri',
-        'derived_from_title', 'print_style', 'version',
+        'derived_from_title', 'print_style', 'version', 'canonical_book_uuid'
         )
 
     def __init__(self, elm_tree, raise_value_error=True):
@@ -159,11 +159,21 @@ class DocumentMetadataParser:
 
     @property
     def revised(self):
-        items = self.parse('.//xhtml:meta[@itemprop="dateModified"]/@content')
-        try:
-            value = items[0]
-        except IndexError:
-            value = None
+        # Grab revised from <meta> if available, otherwise check for a
+        # corresponding data item
+        md_items = self.parse(
+            './/xhtml:meta[@itemprop="dateModified"]/@content'
+        )
+        data_items = self.parse('.//xhtml:*[@data-type="revised"]/@data-value')
+
+        value = None
+        for maybe_item in [md_items, data_items]:
+            try:
+                value = maybe_item[0]
+                break
+            except IndexError:
+                continue
+
         return value
 
     @property
@@ -318,6 +328,13 @@ class DocumentMetadataParser:
     @property
     def derived_from_title(self):
         items = self.parse('.//xhtml:*[@data-type="derived-from"]/text()')
+        if items:
+            return items[0]
+
+    @property
+    def canonical_book_uuid(self):
+        items = self.parse(
+            './/xhtml:*[@data-type="canonical-book-uuid"]/@data-value')
         if items:
             return items[0]
 

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -18,6 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">
@@ -96,6 +97,8 @@
 
    <h1 data-type="document-title">Chapter One</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
@@ -165,6 +168,8 @@
 
    <h1 data-type="document-title">Chapter Two</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
@@ -244,6 +249,8 @@
 
    <h1 data-type="document-title">Chapter Three</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -18,6 +18,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">
@@ -96,6 +97,8 @@
 
    <h1 data-type="document-title">Chapter One</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
@@ -165,6 +168,8 @@
 
    <h1 data-type="document-title">Chapter Two</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">
@@ -244,6 +249,8 @@
 
    <h1 data-type="document-title">Chapter Three</h1><div data-type="page" id="e78d4f90-e078-49d2-beac-e95e8be70667" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
+      <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3"/>
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3"/>
       <div class="authors">

--- a/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
+++ b/cnxepub/tests/data/book/content/e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml
@@ -50,6 +50,7 @@
            a div so that it can be pulled out of the main content editable. -->
       <!-- //@itemprop='name' is perferred over //title -->
       <h1 data-type="document-title" itemprop="name">Document One of Infinity</h1>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
       <span data-type="cnx-archive-uri" data-value="e78d4f90-e078-49d2-beac-e95e8be70667@3" />
       <span data-type="cnx-archive-shortid" data-value="541PkOB4@3" />
 

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -196,6 +196,14 @@
             data-type='document-title'
             itemprop='name'
           >Apple</h1>
+          <span
+            data-type='revised'
+            data-value='2013/03/05 09:35:24 -0500'
+          ></span>
+          <span
+            data-type='canonical-book-uuid'
+            data-value='ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
+          ></span>
           <div
             class='authors'
           >
@@ -292,6 +300,10 @@
             data-type='document-title'
             itemprop='name'
           >Lemon</h1>
+          <span
+            data-type='revised'
+            data-value='2013/03/05 09:35:24 -0500'
+          ></span>
           <div
             class='authors'
           >
@@ -420,6 +432,10 @@
             itemprop='name'
           >Citrus</h1>
           <span
+            data-type='revised'
+            data-value='2013/03/05 09:35:24 -0500'
+          ></span>
+          <span
             data-type='binding'
             data-value='translucent'
           ></span>
@@ -502,6 +518,10 @@
               data-type='document-title'
               itemprop='name'
             >Lemon</h1>
+            <span
+              data-type='revised'
+              data-value='2013/03/05 09:35:24 -0500'
+            ></span>
             <div
               class='authors'
             >
@@ -632,6 +652,10 @@
           data-type='document-title'
           itemprop='name'
         >チョコレート</h1>
+        <span
+          data-type='revised'
+          data-value='2013/03/05 09:35:24 -0500'
+        ></span>
         <div
           class='authors'
         >
@@ -745,6 +769,10 @@
           data-type='document-title'
           itemprop='name'
         >Extra Stuff</h1>
+        <span
+          data-type='revised'
+          data-value='2013/03/05 09:35:24 -0500'
+        ></span>
         <div
           class='authors'
         >

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -197,6 +197,14 @@
             data-type='document-title'
             itemprop='name'
           >Apple</h1>
+          <span
+            data-type='revised'
+            data-value='2013/03/05 09:35:24 -0500'
+          ></span>
+          <span
+            data-type='canonical-book-uuid'
+            data-value='ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
+          ></span>
           <div
             class='authors'
           >
@@ -293,6 +301,10 @@
             data-type='document-title'
             itemprop='name'
           >Lemon</h1>
+          <span
+            data-type='revised'
+            data-value='2013/03/05 09:35:24 -0500'
+          ></span>
           <div
             class='authors'
           >
@@ -465,6 +477,10 @@
             itemprop='name'
           >Citrus</h1>
           <span
+            data-type='revised'
+            data-value='2013/03/05 09:35:24 -0500'
+          ></span>
+          <span
             data-type='binding'
             data-value='translucent'
           ></span>
@@ -547,6 +563,10 @@
               data-type='document-title'
               itemprop='name'
             >Lemon</h1>
+            <span
+              data-type='revised'
+              data-value='2013/03/05 09:35:24 -0500'
+            ></span>
             <div
               class='authors'
             >
@@ -721,6 +741,10 @@
           data-type='document-title'
           itemprop='name'
         >チョコレート</h1>
+        <span
+          data-type='revised'
+          data-value='2013/03/05 09:35:24 -0500'
+        ></span>
         <div
           class='authors'
         >
@@ -834,6 +858,10 @@
           data-type='document-title'
           itemprop='name'
         >Extra Stuff</h1>
+        <span
+          data-type='revised'
+          data-value='2013/03/05 09:35:24 -0500'
+        ></span>
         <div
           class='authors'
         >

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -45,6 +45,8 @@
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
 
       <div class="authors">
         By:
@@ -83,6 +85,7 @@
 
   </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -153,6 +156,7 @@
 
   </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
@@ -178,6 +182,7 @@
 
    <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -248,6 +253,7 @@
 
   </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -289,6 +295,7 @@
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -45,6 +45,8 @@
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
 
       <div class="authors">
         By:
@@ -83,6 +85,7 @@
 
   </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -139,6 +142,7 @@
 
   </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
@@ -164,6 +168,7 @@
 
    <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -220,6 +225,7 @@
 
   </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -261,6 +267,7 @@
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -45,6 +45,8 @@
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
 
       <div class="authors">
         By:
@@ -83,6 +85,7 @@
 
   </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -136,6 +139,7 @@
 
   </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
@@ -161,6 +165,7 @@
 
    <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -214,6 +219,7 @@
 
   </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -255,6 +261,7 @@
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:

--- a/cnxepub/tests/data/desserts-single-page.html
+++ b/cnxepub/tests/data/desserts-single-page.html
@@ -46,6 +46,8 @@
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
 
       <div class="authors">
         By:
@@ -81,6 +83,7 @@
 </ul>
   </div><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -134,6 +137,7 @@
 
   </div><div data-type="chapter"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
       <span data-type="binding" data-value="translucent"></span>
       <div class="authors">
         By:
@@ -159,6 +163,7 @@
 
    <h1 data-type="document-title">Citrus</h1><div class="fruity" data-type="page" id="lemon"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -212,6 +217,7 @@
 
   </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -250,6 +256,7 @@
 </ul></div><img id="auto_chocolate_12302" src="/resources/1x1.jpg"><p id="auto_chocolate_63944">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;&#12487;&#12470;&#12540;&#12488;</p>
   </div><div data-type="composite-page" id="extra"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -45,6 +45,8 @@
 
    <h1 data-type="document-title">Fruity</h1><div data-type="page" id="apple"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Apple</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
+      <span data-type="canonical-book-uuid" data-value="ea4244ce-dd9c-4166-9c97-acae5faf0ba1"/>
 
       <div class="authors">
         By:
@@ -83,6 +85,7 @@
 
   </div><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -136,6 +139,7 @@
 
   </div><div data-type="chapter"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Citrus</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
       <span data-type="binding" data-value="translucent"/>
       <div class="authors">
         By:
@@ -161,6 +165,7 @@
 
    <h1 data-type="document-title">Citrus</h1><div data-type="page" id="lemon" class="fruity"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Lemon</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -214,6 +219,7 @@
 
   </div></div></div><div data-type="page" id="chocolate"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">チョコレート</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:
@@ -255,6 +261,7 @@
 
   </div><div data-type="composite-page" id="extra"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Extra Stuff</h1>
+      <span data-type="revised" data-value="2013/03/05 09:35:24 -0500"/>
 
       <div class="authors">
         By:

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -194,6 +194,7 @@ class EPUBAdaptationTestCase(unittest.TestCase):
             u'language': 'en',
             u'print_style': u'* print style *',
             u'version': None,
+            u'canonical_book_uuid': None
             }
         self.assertEqual(expected_metadata, document.metadata)
 
@@ -681,6 +682,7 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         u'derived_from_title': None,
         u'derived_from_uri': None,
         u'version': None,
+        u'canonical_book_uuid': None
         }
 
     def test_from_formatter_to_adapter(self):
@@ -804,6 +806,8 @@ Pointer.
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Apple'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
+        metadata['canonical_book_uuid'] = 'ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
         apple_metadata = apple.metadata.copy()
         summary = etree.fromstring(apple_metadata.pop('summary'))
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
@@ -820,6 +824,7 @@ Pointer.
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Lemon'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
         lemon_metadata = lemon.metadata.copy()
         summary = etree.fromstring(lemon_metadata.pop('summary'))
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
@@ -849,6 +854,7 @@ Pointer.
         metadata = self.base_metadata.copy()
         metadata['title'] = u'チョコレート'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
         self.assertEqual(metadata, chocolate_metadata)
         self.assertIn(b'<p id="0"><a href="#list">List</a> of',
                       chocolate.content)
@@ -866,6 +872,7 @@ Pointer.
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Extra Stuff'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
         self.assertEqual(metadata, extra_metadata)
         self.assertIn(b'<p id="1">Here is a <a href="/contents/chocolate'
                       b'#list">link</a> to another document.</p>',

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -113,6 +113,7 @@ class ReconstituteTestCase(unittest.TestCase):
             u'derived_from_title': None,
             u'derived_from_uri': None,
             u'version': None,
+            u'canonical_book_uuid': None
             }
 
         fruity = desserts[0]
@@ -124,6 +125,8 @@ class ReconstituteTestCase(unittest.TestCase):
         metadata = base_metadata.copy()
         metadata['title'] = 'Apple'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
+        metadata['canonical_book_uuid'] = 'ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
         apple_metadata = apple.metadata.copy()
         summary = etree.fromstring(apple_metadata.pop('summary'))
         self.assertEqual('{http://www.w3.org/1999/xhtml}p', summary.tag)
@@ -135,6 +138,7 @@ class ReconstituteTestCase(unittest.TestCase):
         metadata = base_metadata.copy()
         metadata['title'] = 'Lemon'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
         apple_metadata = apple.metadata.copy()
         lemon_metadata = lemon.metadata.copy()
         summary = etree.fromstring(lemon_metadata.pop('summary'))
@@ -157,6 +161,7 @@ class ReconstituteTestCase(unittest.TestCase):
         metadata = base_metadata.copy()
         metadata['title'] = u'チョコレート'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
         apple_metadata = apple.metadata.copy()
         self.assertEqual(metadata, chocolate_metadata)
 
@@ -169,6 +174,7 @@ class ReconstituteTestCase(unittest.TestCase):
         metadata = base_metadata.copy()
         metadata['title'] = 'Extra Stuff'
         metadata['version'] = '1.3'
+        metadata['revised'] = '2013/03/05 09:35:24 -0500'
         self.assertEqual(metadata, extra_metadata)
 
 

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -475,6 +475,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         # Build test document.
         metadata = self.base_metadata.copy()
+        metadata['canonical_book_uuid'] = 'ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
         document = Document(
             metadata['title'],
             io.BytesIO(u'<body><p>コンテンツ...</p></body>'.encode('utf-8')),
@@ -502,6 +503,15 @@ class HTMLFormatterTestCase(unittest.TestCase):
         self.assertEqual(
             metadata['revised'],
             self.xpath('//xhtml:meta[@itemprop="dateModified"]/@content')[0])
+
+        self.assertEqual(
+            metadata['revised'],
+            self.xpath('.//xhtml:*[@data-type="revised"]/@data-value')[0])
+
+        self.assertEqual(
+            'ea4244ce-dd9c-4166-9c97-acae5faf0ba1',
+            self.xpath('.//xhtml:*[@data-type="canonical-book-uuid"]/@data-value')[0]
+        )
 
     def test_document_pointer(self):
         from ..models import DocumentPointer
@@ -693,6 +703,7 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
 
         metadata = self.base_metadata.copy()
         metadata['title'] = 'Apple'
+        metadata['canonical_book_uuid'] = 'ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
         contents = io.BytesIO(b"""\
 <body>
 <h1>Apple Desserts</h1>

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -63,5 +63,6 @@ class HTMLParsingTestCase(unittest.TestCase):
             'print_style': '* print style *',
             'language': 'en',
             'version': '3',
+            'canonical_book_uuid': 'ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
             }
         self.assertEqual(metadata, expected_metadata)


### PR DESCRIPTION
This change adds a new `canonical_book_uuid` metadata field and also
modifies the behavior of `revised` so that it gets stored for each
page in an assembled XHTML file.