### PR TITLE
Add support for slug metadata and account for optional data

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -579,17 +579,21 @@ HTML_DOCUMENT = """\
       xmlns:mod="http://cnx.rice.edu/#moduleIds"
       xmlns:md="http://cnx.rice.edu/mdml"
       xmlns:c="http://cnx.rice.edu/cnxml"
+      {% if metadata.get('language') %}
       lang="{{ metadata['language'] }}"
+      {% endif %}
       >
   <head itemscope="itemscope"
         itemtype="http://schema.org/Book"
         >
 
     <title>{{ metadata['title'] }}</title>
+    {% if metadata.get('language') %}
     <meta itemprop="inLanguage"
           data-type="language"
           content="{{ metadata['language'] }}"
           />
+    {% endif %}
 
     {# TODO Include this based on the feature being present #}
     <!-- These are for discoverability of accessible content. -->

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -633,6 +633,10 @@ HTML_DOCUMENT = """\
       <span data-type="canonical-book-uuid" data-value="{{ \
           metadata['canonical_book_uuid'] }}" />
       {% endif %}
+      {% if metadata.get('slug') %}
+      <span data-type="slug" data-value="{{ \
+          metadata['slug'] }}" />
+      {% endif %}
       {% if is_translucent %}
       <span data-type="binding" data-value="translucent" />
       {%- endif %}

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -607,9 +607,11 @@ HTML_DOCUMENT = """\
        <meta refines="#<html-id>" property="display-seq" content="<ord>" />
      #}
 
+    {% if metadata.get('created') %}
     <meta itemprop="dateCreated"
           content="{{ metadata['created'] }}"
           />
+    {% endif %}
     <meta itemprop="dateModified"
           content="{{ metadata['revised'] }}"
           />

--- a/cnxepub/html_parsers.py
+++ b/cnxepub/html_parsers.py
@@ -98,7 +98,7 @@ class DocumentMetadataParser:
         'publishers', 'copyright_holders', 'authors', 'summary',
         'cnx-archive-uri', 'cnx-archive-shortid', 'derived_from_uri',
         'derived_from_title', 'print_style', 'version', 'canonical_book_uuid',
-        'license_url',
+        'license_url', 'slug'
         )
 
     def __init__(self, elm_tree, raise_value_error=True):
@@ -336,6 +336,13 @@ class DocumentMetadataParser:
     def canonical_book_uuid(self):
         items = self.parse(
             './/xhtml:*[@data-type="canonical-book-uuid"]/@data-value')
+        if items:
+            return items[0]
+
+    @property
+    def slug(self):
+        items = self.parse(
+            './/xhtml:*[@data-type="slug"]/@data-value')
         if items:
             return items[0]
 

--- a/cnxepub/tests/data/book-single-page-py2.xhtml
+++ b/cnxepub/tests/data/book-single-page-py2.xhtml
@@ -19,6 +19,7 @@
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="slug" data-value="infinity"/>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">

--- a/cnxepub/tests/data/book-single-page.xhtml
+++ b/cnxepub/tests/data/book-single-page.xhtml
@@ -19,6 +19,7 @@
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
       <span data-type="revised" data-value="2013/06/18 15:22:55 -0500"/>
+      <span data-type="slug" data-value="infinity"/>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6"/>
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6"/>
       <div class="authors">

--- a/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
+++ b/cnxepub/tests/data/book/content/9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6.xhtml
@@ -46,6 +46,7 @@
            a div so that it can be pulled out of the main content editable. -->
       <!-- //@itemprop='name' is perferred over //title -->
       <h1 data-type="document-title" itemprop="name">Book of Infinity</h1>
+      <span data-type="slug" data-value="infinity"/>
       <span data-type="cnx-archive-uri" data-value="9b0903d2-13c4-4ebe-9ffe-1ee79db28482@1.6" />
       <span data-type="cnx-archive-shortid" data-value="mwkD0hPE@1.6" />
 

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -51,6 +51,10 @@
         itemprop='name'
       >Desserts</h1>
       <span
+        data-type='slug'
+        data-value='desserts'
+      ></span>
+      <span
         data-type='cnx-archive-uri'
         data-value='00000000-0000-0000-0000-000000000000@1.3'
       ></span>

--- a/cnxepub/tests/data/desserts-includes-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-py2.xhtml
@@ -35,10 +35,6 @@
     ></meta>
     <meta
       content=''
-      itemprop='dateCreated'
-    ></meta>
-    <meta
-      content=''
       itemprop='dateModified'
     ></meta>
   </head>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -52,6 +52,10 @@
         itemprop='name'
       >Desserts</h1>
       <span
+        data-type='slug'
+        data-value='desserts'
+      ></span>
+      <span
         data-type='cnx-archive-uri'
         data-value='00000000-0000-0000-0000-000000000000@1.3'
       ></span>

--- a/cnxepub/tests/data/desserts-includes-token-py2.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token-py2.xhtml
@@ -36,10 +36,6 @@
     ></meta>
     <meta
       content=''
-      itemprop='dateCreated'
-    ></meta>
-    <meta
-      content=''
       itemprop='dateModified'
     ></meta>
   </head>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -12,7 +12,6 @@
     <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta itemprop="dateCreated" content=""/>
     <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -17,6 +17,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="slug" data-value="desserts"/>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -12,7 +12,6 @@
     <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta itemprop="dateCreated" content=""/>
     <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -17,6 +17,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="slug" data-value="desserts"/>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -12,7 +12,6 @@
     <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta itemprop="dateCreated" content=""/>
     <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -17,6 +17,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="slug" data-value="desserts"/>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -12,7 +12,6 @@
     <meta itemprop="accessibilityFeature" content="structuredNavigation"/>
 
 
-    <meta itemprop="dateCreated" content=""/>
     <meta itemprop="dateModified" content=""/>
   </head>
   <body itemscope="itemscope" itemtype="http://schema.org/Book">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -17,6 +17,7 @@
   <body itemscope="itemscope" itemtype="http://schema.org/Book">
     <div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Desserts</h1>
+      <span data-type="slug" data-value="desserts"/>
       <span data-type="cnx-archive-uri" data-value="00000000-0000-0000-0000-000000000000@1.3"/>
 
       <div class="permissions">

--- a/cnxepub/tests/test_adapters.py
+++ b/cnxepub/tests/test_adapters.py
@@ -194,7 +194,8 @@ class EPUBAdaptationTestCase(unittest.TestCase):
             u'language': 'en',
             u'print_style': u'* print style *',
             u'version': None,
-            u'canonical_book_uuid': None
+            u'canonical_book_uuid': None,
+            u'slug': None,
             }
         self.assertEqual(expected_metadata, document.metadata)
 
@@ -682,7 +683,8 @@ class HTMLAdaptationTestCase(unittest.TestCase):
         u'derived_from_title': None,
         u'derived_from_uri': None,
         u'version': None,
-        u'canonical_book_uuid': None
+        u'canonical_book_uuid': None,
+        u'slug': None,
         }
 
     def test_from_formatter_to_adapter(self):

--- a/cnxepub/tests/test_collation.py
+++ b/cnxepub/tests/test_collation.py
@@ -113,7 +113,8 @@ class ReconstituteTestCase(unittest.TestCase):
             u'derived_from_title': None,
             u'derived_from_uri': None,
             u'version': None,
-            u'canonical_book_uuid': None
+            u'canonical_book_uuid': None,
+            u'slug': None,
             }
 
         fruity = desserts[0]

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -549,6 +549,27 @@ class HTMLFormatterTestCase(unittest.TestCase):
             len(self.xpath('//xhtml:meta[@itemprop="inLanguage"]/@content'))
         )
 
+    def test_document_nocreated(self):
+        from ..models import Document
+        from ..formatters import HTMLFormatter
+
+        # Build test document.
+        metadata = self.base_metadata.copy()
+        metadata['created'] = None
+        document = Document(
+            metadata['title'],
+            io.BytesIO(b'<body><p>Hello.</p></body>'),
+            metadata=metadata)
+
+        html = str(HTMLFormatter(document))
+        html = unescape(html)
+        self.root = etree.fromstring(html.encode('utf-8'))
+
+        self.assertEqual(
+            0,
+            len(self.xpath('//xhtml:meta[@itemprop="dateCreated"]/@content'))
+        )
+
     def test_document_pointer(self):
         from ..models import DocumentPointer
         from ..formatters import HTMLFormatter

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -840,7 +840,8 @@ class SingleHTMLFormatterTestCase(unittest.TestCase):
                       'license_url': 'http://creativecommons.org/licenses/by/4.0/',
                       'license_text': 'CC-By 4.0',
                       'cnx-archive-uri': '00000000-0000-0000-0000-000000000000@1.3',
-                      'language': 'en'},
+                      'language': 'en',
+                      'slug': 'desserts'},
             resources=[cover_png])
 
     def test_binder(self):

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -513,6 +513,42 @@ class HTMLFormatterTestCase(unittest.TestCase):
             self.xpath('.//xhtml:*[@data-type="canonical-book-uuid"]/@data-value')[0]
         )
 
+        self.assertEqual(
+            metadata['language'],
+            self.xpath('//xhtml:html/@lang')[0]
+        )
+
+        self.assertEqual(
+            metadata['language'],
+            self.xpath('//xhtml:meta[@itemprop="inLanguage"]/@content')[0]
+        )
+
+    def test_document_nolang(self):
+        from ..models import Document
+        from ..formatters import HTMLFormatter
+
+        # Build test document.
+        metadata = self.base_metadata.copy()
+        metadata['language'] = None
+        document = Document(
+            metadata['title'],
+            io.BytesIO(b'<body><p>Hello.</p></body>'),
+            metadata=metadata)
+
+        html = str(HTMLFormatter(document))
+        html = unescape(html)
+        self.root = etree.fromstring(html.encode('utf-8'))
+
+        self.assertEqual(
+            0,
+            len(self.xpath('//xhtml:html/@lang'))
+        )
+
+        self.assertEqual(
+            0,
+            len(self.xpath('//xhtml:meta[@itemprop="inLanguage"]/@content'))
+        )
+
     def test_document_pointer(self):
         from ..models import DocumentPointer
         from ..formatters import HTMLFormatter

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -509,7 +509,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
             self.xpath('.//xhtml:*[@data-type="revised"]/@data-value')[0])
 
         self.assertEqual(
-            'ea4244ce-dd9c-4166-9c97-acae5faf0ba1',
+            metadata['canonical_book_uuid'],
             self.xpath('.//xhtml:*[@data-type="canonical-book-uuid"]/@data-value')[0]
         )
 

--- a/cnxepub/tests/test_html_parsers.py
+++ b/cnxepub/tests/test_html_parsers.py
@@ -63,6 +63,7 @@ class HTMLParsingTestCase(unittest.TestCase):
             'print_style': '* print style *',
             'language': 'en',
             'version': '3',
-            'canonical_book_uuid': 'ea4244ce-dd9c-4166-9c97-acae5faf0ba1'
+            'canonical_book_uuid': 'ea4244ce-dd9c-4166-9c97-acae5faf0ba1',
+            'slug': None,
             }
         self.assertEqual(metadata, expected_metadata)


### PR DESCRIPTION
This PR includes the following changes:

* Support use of `slug` metadata in HTML formatter and parser
* Avoid output of elements that use `language` metadata when it is not available
* Avoid output of elements that use `created` metadata when it is not available