### PR TITLE
Remove parsing of exercise element for error messages

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -455,8 +455,6 @@ def exercise_callback_factory(match, url_template,
         # book, or even invalid altogether. We'll prefer the first, fallback
         # to the second, and error in the last case.
 
-        # Determine parent page and exercise for this element
-        exercise_elem = elem.xpath('ancestor::*[@data-type="exercise"]')[0]
         parent_page_elem = elem.xpath('ancestor::*[@data-type="page"]')[0]
         parent_page_uuid = parent_page_elem.get('id')
         if parent_page_uuid.startswith('page_'):
@@ -482,8 +480,8 @@ def exercise_callback_factory(match, url_template,
         if len(candidate_uuids) == 0:
             # No valid page UUIDs in exercise data
             msg = 'No candidate uuid for exercise feature {} '.format(feature)
-            msg += '(exercise href: {} / exercise ID: {})'.format(
-                elem.get('href'), exercise_elem.get('id')
+            msg += '(exercise href: {})'.format(
+                elem.get('href')
             )
             logger.error(msg)
             raise Exception(msg)
@@ -512,8 +510,8 @@ def exercise_callback_factory(match, url_template,
 
         if feature_element is None:
             msg = 'Feature {} not in {} '.format(feature, target_module)
-            msg += '(exercise href: {} / exercise ID: {})'.format(
-                elem.get('href'), exercise_elem.get('id')
+            msg += '(exercise href: {})'.format(
+                elem.get('href')
             )
             logger.error(msg)
             raise Exception(msg)

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -1204,7 +1204,7 @@ class ExerciseAnnotationTestCase(unittest.TestCase):
         self.assertEqual(
             str(error.exception),
             'No candidate uuid for exercise feature feature-donotexist '
-            '(exercise href: #ost/api/ex/book-ch01-ex001 / exercise ID: exercise-1)'
+            '(exercise href: #ost/api/ex/book-ch01-ex001)'
         )
 
     @mock.patch('cnxepub.formatters.requests.get')
@@ -1317,7 +1317,7 @@ class ExerciseAnnotationTestCase(unittest.TestCase):
         self.assertEqual(
             str(error.exception),
             'Feature feature-donotexist not in uuid2 '
-            '(exercise href: #ost/api/ex/book-ch01-ex001 / exercise ID: exercise-1)'
+            '(exercise href: #ost/api/ex/book-ch01-ex001)'
         )
 
     @mock.patch('cnxepub.formatters.requests.get')
@@ -1339,7 +1339,7 @@ class ExerciseAnnotationTestCase(unittest.TestCase):
         self.assertEqual(
             str(error.exception),
             'No candidate uuid for exercise feature feature-donotexist '
-            '(exercise href: #ost/api/ex/book-ch01-ex001 / exercise ID: exercise-1)'
+            '(exercise href: #ost/api/ex/book-ch01-ex001)'
         )
 
     @mock.patch('cnxepub.formatters.requests.get')


### PR DESCRIPTION
This fixes an incorrect assumption that all exercise link references
occur nested within an `<exercise>`. Those were only being parsed for
debug information in error messages anyways, so removing the parsing
altogether.