### PR TITLE
Add the template back into a python file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,9 @@ jobs:
       - name: Lint
         run: |
           pip install pep8
-          pep8 --exclude=tests *.py cnxepub/
+          pep8 --exclude=tests,templates *.py cnxepub/
           pep8 --max-line-length=1000 cnxepub/tests
+          pep8 --max-line-length=1000 cnxepub/templates
       - name: Test
         run: |
           pip install -U pip

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,3 @@ include *.txt *.rst
 recursive-include cnxepub/tests/data *.*
 include versioneer.py
 include cnxepub/_version.py
-recursive-include cnxepub/templates *.jinja

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -27,6 +27,7 @@ from .models import (
     Document, DocumentPointer, CompositeDocument, utf8)
 from .html_parsers import HTML_DOCUMENT_NAMESPACES
 from .utils import ThreadPoolExecutor
+from .templates.exercise_template import EXERCISE_TEMPLATE
 
 logger = logging.getLogger('cnxepub')
 
@@ -587,14 +588,7 @@ def render_exercise(exercise):
         raise Exception('Exercise "items" array is nonsingular')
     exercise_content = exercise['items'][0]
 
-    # Load template
-    env = jinja2.Environment(
-        loader=jinja2.PackageLoader("cnxepub"),
-        autoescape=jinja2.select_autoescape()
-    )
-    template = env.get_template("exercise_template.xhtml.jinja")
-
-    return template.render(data=exercise_content)
+    return EXERCISE_TEMPLATE.render(data=exercise_content)
 
 
 DOCUMENT_POINTER_TEMPLATE = """\

--- a/cnxepub/templates/exercise_template.py
+++ b/cnxepub/templates/exercise_template.py
@@ -1,4 +1,7 @@
-<div 
+import jinja2
+
+EXERCISE_TEMPLATE_STR = """\
+<div
     data-type="injected-exercise"
     data-injected-from-nickname="{{ data.nickname }}"
     data-injected-from-version="{{ data.version }}"
@@ -17,7 +20,7 @@
     <div data-type="exercise-stimulus">{{ data.stimulus_html }}</div>
     {% endif -%}
     {% for question in data.questions -%}
-    <div 
+    <div
         data-type="exercise-question"
         data-is-answer-order-important="{{ question.is_answer_order_important | lower }}"
         data-formats="{{ ' '.join(question.formats) }}"
@@ -50,3 +53,6 @@
     </div>
     {% endfor -%}
 </div>
+"""
+
+EXERCISE_TEMPLATE = jinja2.Template(EXERCISE_TEMPLATE_STR)


### PR DESCRIPTION
cnx-epub is packaged up using bdist_wheel which [does not allow resource files](https://stackoverflow.com/questions/24727709/do-python-projects-need-a-manifest-in-and-what-should-be-in-it#comment46447382_24727824) since these packages are intended to run from the PATH. Since it does not allow resource files the Jija template cannot be loaded as a resource.

Refs https://github.com/openstax/cnx-epub/pull/179