### PR TITLE
Remove HTML-parsing fallback

### DIFF
--- a/cnxepub/collation.py
+++ b/cnxepub/collation.py
@@ -41,12 +41,8 @@ def easybake(ruleset, in_html, out_html):
 
 def reconstitute(html):
     """Given a file-like object as ``html``, reconstruct it into models."""
-    try:
-        htree = etree.parse(html)
-    except etree.XMLSyntaxError:
-        html.seek(0)
-        htree = etree.HTML(html.read())
-
+    html.seek(0)
+    htree = etree.parse(html)
     xhtml = etree.tostring(htree, encoding='utf-8')
     return adapt_single_html(xhtml)
 


### PR DESCRIPTION
The MathML namespace is currently being stripped in all content because `html` was already read once

Alternate solution: https://github.com/openstax/output-producer-service/pull/410

Example HTML where the [MathML namespace is stripped](https://openstax.org/apps/archive/20210823.155019/contents/031da8d3-b525-429c-80cf-6c8ed997733a@23.42:c82515ee-02ef-4e15-9b4f-52e67617359c.xhtml)
