### PR TITLE
:bug: fix ToC links

### DIFF
--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -825,7 +825,7 @@ def html_listify(tree, root_xl_element, extensions, list_type='ol'):
         else:
             a_elm = lxml.html.fragment_fromstring(
                 node['title'], create_parent='a')
-            a_elm.set('href', ''.join(['#page_', node['id']]))
+            a_elm.set('href', ''.join(['#page_', node['id'].split('@')[0]]))
             li_elm.append(a_elm)
         if node['id'] is not None and node['id'] != 'subcol':
             li_elm.set('cnx-archive-uri', node['id'])

--- a/cnxepub/formatters.py
+++ b/cnxepub/formatters.py
@@ -825,7 +825,7 @@ def html_listify(tree, root_xl_element, extensions, list_type='ol'):
         else:
             a_elm = lxml.html.fragment_fromstring(
                 node['title'], create_parent='a')
-            a_elm.set('href', ''.join([node['id'], extensions[node['id']]]))
+            a_elm.set('href', ''.join(['#page_', node['id']]))
             li_elm.append(a_elm)
         if node['id'] is not None and node['id'] != 'subcol':
             li_elm.set('cnx-archive-uri', node['id'])

--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -55,7 +55,7 @@
       </div>
     </div>
 
-   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="apple@draft.xhtml">Apple</a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="#page_apple@draft">Apple</a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li><a href="#page_chocolate@draft">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
   <div data-type="unit">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>

--- a/cnxepub/tests/data/collated-desserts-single-page.xhtml
+++ b/cnxepub/tests/data/collated-desserts-single-page.xhtml
@@ -55,7 +55,7 @@
       </div>
     </div>
 
-   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="#page_apple@draft">Apple</a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li><a href="#page_chocolate@draft">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li><span>Fruity</span><ol><li><a href="#page_apple">Apple</a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li><a href="#page_lemon">Lemon</a></li></ol></li></ol></li><li><a href="#page_chocolate">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li><li><a href="#page_extra">Extra Stuff</a></li></ol></nav>
   <div data-type="unit">
     <div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-includes-token.xhtml
+++ b/cnxepub/tests/data/desserts-includes-token.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-includes.xhtml
+++ b/cnxepub/tests/data/desserts-includes.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">EXTRA STUFF</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">APPLE</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">LEMON</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">EXTRA STUFF</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page-ampersand.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-ampersand.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page-ampersand.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-ampersand.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page-bad-type.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-bad-type.xhtml
@@ -31,7 +31,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page-bad-type.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-bad-type.xhtml
@@ -31,7 +31,7 @@
 <li><a href="cover.png">cover.png</a></li>        </ul>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-shortid="frt" cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page-bad.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-bad.xhtml
@@ -58,18 +58,18 @@
        <ol>
          <li><span>Fruity</span>
              <ol>
-               <li><a href="apple@draft.xhtml">Apple</a></li>
-               <li><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li>
+               <li><a href="#page_apple@draft">Apple</a></li>
+               <li><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li>
                <li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span>
                  <ol>
-                   <li><a href="lemon@draft.xhtml">Lemon</a></li>
+                   <li><a href="#page_lemon@draft">Lemon</a></li>
                  </ol>
                </li>
              </ol>
          </li>
-         <li><a href="chocolate@draft.xhtml">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li>
-         <li><a href="extra@draft.xhtml">Extra Stuff</a></li>
-         <li><a href="extra@draft.xhtml">Extra, Extra Stuff</a></li>
+         <li><a href="#page_chocolate@draft">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li>
+         <li><a href="#page_extra@draft">Extra Stuff</a></li>
+         <li><a href="#page_extra@draft">Extra, Extra Stuff</a></li>
        </ol>
    </nav>
   <div data-type="unit">

--- a/cnxepub/tests/data/desserts-single-page-bad.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-bad.xhtml
@@ -58,18 +58,18 @@
        <ol>
          <li><span>Fruity</span>
              <ol>
-               <li><a href="#page_apple@draft">Apple</a></li>
-               <li><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li>
+               <li><a href="#page_apple">Apple</a></li>
+               <li><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>&#12524;&#12514;&#12531;</span></a></li>
                <li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span>
                  <ol>
-                   <li><a href="#page_lemon@draft">Lemon</a></li>
+                   <li><a href="#page_lemon">Lemon</a></li>
                  </ol>
                </li>
              </ol>
          </li>
-         <li><a href="#page_chocolate@draft">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li>
-         <li><a href="#page_extra@draft">Extra Stuff</a></li>
-         <li><a href="#page_extra@draft">Extra, Extra Stuff</a></li>
+         <li><a href="#page_chocolate">&#12481;&#12519;&#12467;&#12524;&#12540;&#12488;</a></li>
+         <li><a href="#page_extra">Extra Stuff</a></li>
+         <li><a href="#page_extra">Extra, Extra Stuff</a></li>
        </ol>
    </nav>
   <div data-type="unit">

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page-py2.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-py2.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page-umlaut.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-umlaut.xhtml
@@ -27,7 +27,7 @@
     </div>
         </div>
 
- <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
+ <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra">Extra Stuff</a></li></ol></nav>
 <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Fruityäüö</h1>
     <div class="permissions">

--- a/cnxepub/tests/data/desserts-single-page-umlaut.xhtml
+++ b/cnxepub/tests/data/desserts-single-page-umlaut.xhtml
@@ -27,7 +27,7 @@
     </div>
         </div>
 
- <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+ <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
 <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
     <h1 data-type="document-title" itemprop="name">Fruityäüö</h1>
     <div class="permissions">

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="apple@draft.xhtml">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="lemon@draft.xhtml">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="chocolate@draft.xhtml">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="extra@draft.xhtml">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/desserts-single-page.xhtml
+++ b/cnxepub/tests/data/desserts-single-page.xhtml
@@ -27,7 +27,7 @@
         </p>
       </div>    </div>
 
-   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple@draft">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon@draft">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate@draft">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra@draft">Extra Stuff</a></li></ol></nav>
+   <nav id="toc"><ol><li cnx-archive-uri="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2" cnx-archive-shortid="frt"><span>Fruity</span><ol><li cnx-archive-uri="apple@draft"><a href="#page_apple">Apple</a></li><li cnx-archive-uri="lemon@draft"><a href="#page_lemon"><span>1.1</span> <span>|</span> <span>レモン</span></a></li><li><span><span>Chapter</span> <span>2</span> <span>citrus</span></span><ol><li cnx-archive-uri="lemon@draft"><a href="#page_lemon">Lemon</a></li></ol></li></ol></li><li cnx-archive-uri="chocolate@draft"><a href="#page_chocolate">チョコレート</a></li><li cnx-archive-uri="extra@draft"><a href="#page_extra">Extra Stuff</a></li></ol></nav>
   <div data-type="unit" id="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2"><div data-type="metadata" style="display: none;">
       <h1 data-type="document-title" itemprop="name">Fruity</h1>
       <span data-type="cnx-archive-uri" data-value="ec84e75d-9973-41f1-ab9d-1a3ebaef87e2@1.3"/>

--- a/cnxepub/tests/data/nav-tree.xhtml
+++ b/cnxepub/tests/data/nav-tree.xhtml
@@ -155,7 +155,7 @@
 	      <span>Chapter One</span>
 	      <ol>
 		<li>
-		  <a href="e78d4f90-e078-49d2-beac-e95e8be70667@3.xhtml">Document One</a>
+		  <a href="#page_e78d4f90-e078-49d2-beac-e95e8be70667">Document One</a>
 		</li>
 	      </ol>
 	    </li>
@@ -163,7 +163,7 @@
 	      <span>Chapter Two</span>
 	      <ol>
 		<li>
-		  <a href="3c448dc6-d5f5-43d5-8df7-fe27d462bd3a@1.xhtml">Document Two</a>
+		  <a href="#page_3c448dc6-d5f5-43d5-8df7-fe27d462bd3a">Document Two</a>
 		</li>
 	      </ol>
 	    </li>
@@ -176,7 +176,7 @@
 	      <span>Chapter Three</span>
 	      <ol>
 		<li>
-		  <a href="ad17c39c-d606-4441-b987-54448020bb40@2.xhtml">Document Three</a>
+		  <a href="#page_ad17c39c-d606-4441-b987-54448020bb40">Document Three</a>
 		</li>
 	      </ol>
 	    </li>
@@ -189,7 +189,7 @@
 	      <span>Chapter Four</span>
 	      <ol>
 		<li>
-		  <a href="7c52af05-05b1-4761-aa4c-b17b0197dc6d@1.xhtml">Document Four</a>
+		  <a href="#page_7c52af05-05b1-4761-aa4c-b17b0197dc6d">Document Four</a>
 		</li>
 	      </ol>
 	    </li>

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -724,15 +724,15 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li')
         self.assertEqual(3, len(lis))
-        self.assertEqual('#page_ingress@draft', lis[0][0].attrib['href'])
+        self.assertEqual('#page_ingress', lis[0][0].attrib['href'])
         self.assertEqual(u'entrée', lis[0][0].text)
         self.assertEqual('Kranken', lis[1][0].text)
-        self.assertEqual('#page_pointer@1', lis[2][0].attrib['href'])
+        self.assertEqual('#page_pointer', lis[2][0].attrib['href'])
         self.assertEqual('Pointer', lis[2][0].text)
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li[2]/xhtml:ol/xhtml:li')
         self.assertEqual(1, len(lis))
-        self.assertEqual('#page_egress@draft', lis[0][0].attrib['href'])
+        self.assertEqual('#page_egress', lis[0][0].attrib['href'])
         self.assertEqual('egress', lis[0][0].text)
 
     def test_translucent_binder(self):
@@ -763,7 +763,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li')
         self.assertEqual(1, len(lis))
-        self.assertEqual('#page_ingress@draft', lis[0][0].attrib['href'])
+        self.assertEqual('#page_ingress', lis[0][0].attrib['href'])
         self.assertEqual(u'entrée', lis[0][0].text)
 
     def test_document_auto_generate_ids(self):

--- a/cnxepub/tests/test_formatters.py
+++ b/cnxepub/tests/test_formatters.py
@@ -724,15 +724,15 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li')
         self.assertEqual(3, len(lis))
-        self.assertEqual('ingress@draft.xhtml', lis[0][0].attrib['href'])
+        self.assertEqual('#page_ingress@draft', lis[0][0].attrib['href'])
         self.assertEqual(u'entrée', lis[0][0].text)
         self.assertEqual('Kranken', lis[1][0].text)
-        self.assertEqual('pointer@1.xhtml', lis[2][0].attrib['href'])
+        self.assertEqual('#page_pointer@1', lis[2][0].attrib['href'])
         self.assertEqual('Pointer', lis[2][0].text)
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li[2]/xhtml:ol/xhtml:li')
         self.assertEqual(1, len(lis))
-        self.assertEqual('egress@draft.xhtml', lis[0][0].attrib['href'])
+        self.assertEqual('#page_egress@draft', lis[0][0].attrib['href'])
         self.assertEqual('egress', lis[0][0].text)
 
     def test_translucent_binder(self):
@@ -763,7 +763,7 @@ class HTMLFormatterTestCase(unittest.TestCase):
 
         lis = self.xpath('//xhtml:nav/xhtml:ol/xhtml:li')
         self.assertEqual(1, len(lis))
-        self.assertEqual('ingress@draft.xhtml', lis[0][0].attrib['href'])
+        self.assertEqual('#page_ingress@draft', lis[0][0].attrib['href'])
         self.assertEqual(u'entrée', lis[0][0].text)
 
     def test_document_auto_generate_ids(self):


### PR DESCRIPTION
The assembled HTML contained Page elements that looked like this: `<div data-type="page" id="page_{uuid}">` but the ToC that was added contained invalid links that looked like this: `<a href="{uuid}@.xhtml">`

Refs https://github.com/openstax/ce/issues/1966